### PR TITLE
remove empty leaf nodes on search dialog, fix compiler (java) compiler warnings

### DIFF
--- a/src/main/java/axoloti/ObjectSearchFrame.java
+++ b/src/main/java/axoloti/ObjectSearchFrame.java
@@ -51,6 +51,7 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
 
     /**
      * Creates new form ObjectSearchFrame
+     * @param p parent 
      */
     public ObjectSearchFrame(PatchGUI p) {
         initComponents();

--- a/src/main/java/axoloti/TextEditor.java
+++ b/src/main/java/axoloti/TextEditor.java
@@ -29,6 +29,7 @@ public class TextEditor extends javax.swing.JFrame {
 
     /**
      * Creates new form TextEditor
+     * @param s initial string
      */
     public TextEditor(StringRef s) {
         initComponents();

--- a/src/main/java/axoloti/dialogs/CodeDialog.java
+++ b/src/main/java/axoloti/dialogs/CodeDialog.java
@@ -25,6 +25,8 @@ public class CodeDialog extends javax.swing.JDialog {
 
     /**
      * Creates new form CodeDialog
+     * @param parent parent frame
+     * @param modal is modal
      */
     public CodeDialog(java.awt.Frame parent, boolean modal) {
         super(parent, modal);

--- a/src/main/java/axoloti/dialogs/PatchSettingsFrame.java
+++ b/src/main/java/axoloti/dialogs/PatchSettingsFrame.java
@@ -34,6 +34,7 @@ public class PatchSettingsFrame extends javax.swing.JFrame {
 
     /**
      * Creates new form PatchSettingsFrame
+     * @param settings settings to load/save 
      */
     public PatchSettingsFrame(PatchSettings settings) {
         initComponents();

--- a/src/main/java/axoloti/dialogs/PreferencesFrame.java
+++ b/src/main/java/axoloti/dialogs/PreferencesFrame.java
@@ -29,6 +29,7 @@ public class PreferencesFrame extends javax.swing.JFrame {
 
     /**
      * Creates new form PreferencesFrame
+     * @param prefs preferences to load/save
      */
     public PreferencesFrame(Preferences prefs) {
         initComponents();

--- a/src/main/java/axoloti/dialogs/SerialPortSelectionDlg.java
+++ b/src/main/java/axoloti/dialogs/SerialPortSelectionDlg.java
@@ -27,10 +27,13 @@ public class SerialPortSelectionDlg extends javax.swing.JDialog {
 
     private String[] ports;
     private String port;
-    private String defPortName;
+    private final String defPortName;
 
     /**
      * Creates new form SerialPortSelectionDlg
+     * @param parent parent frame
+     * @param modal is modal
+     * @param defPortName default port name
      */
     public SerialPortSelectionDlg(java.awt.Frame parent, boolean modal, String defPortName) {
         super(parent, modal);

--- a/src/main/java/axoloti/object/AxoObjects.java
+++ b/src/main/java/axoloti/object/AxoObjects.java
@@ -188,12 +188,15 @@ public class AxoObjects {
             if (fileEntry.isDirectory()) {
                 String dirname = fileEntry.getName();
                 AxoObjectTreeNode s = LoadAxoObjectsFromFolder(fileEntry, prefix + "/" + dirname);
-                t.SubNodes.put(dirname, s);
-                for (AxoObjectAbstract o : t.Objects) {
-                    int i = o.id.lastIndexOf('/');
-                    if (i > 0) {
-                        if (o.id.substring(i + 1).equals(dirname)) {
-                            s.Objects.add(o);
+                if(s.Objects.size()>0 || s.SubNodes.size()>0)
+                {
+                    t.SubNodes.put(dirname, s);
+                    for (AxoObjectAbstract o : t.Objects) {
+                        int i = o.id.lastIndexOf('/');
+                        if (i > 0) {
+                            if (o.id.substring(i + 1).equals(dirname)) {
+                                s.Objects.add(o);
+                            }
                         }
                     }
                 }
@@ -240,7 +243,10 @@ public class AxoObjects {
         File folder = new File(path);
         if (folder.isDirectory()) {
             AxoObjectTreeNode t = LoadAxoObjectsFromFolder(folder, "");
-            ObjectTree.SubNodes.put(folder.getName(), t);
+            if(t.Objects.size()>0 || t.SubNodes.size()>0)
+            {
+                ObjectTree.SubNodes.put(folder.getName(), t);
+            }
         }
     }
 

--- a/src/main/java/components/PresetPanel.java
+++ b/src/main/java/components/PresetPanel.java
@@ -29,6 +29,7 @@ public class PresetPanel extends javax.swing.JPanel {
 
     /**
      * Creates new form PresetPanel
+     * @param p patch to recall preset
      */
     public PresetPanel(Patch p) {
         this.p = p;


### PR DESCRIPTION
- search dialog showed empty nodes (which look liked objects), now only shows directories which (at some level) contains axo files.
- java fixed compiler warnings when compiling with ant  (missing param tags)