### PR TITLE
support midi device/port selecton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 
+# Xcode project
+xcode/

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -157,6 +157,7 @@ CSRC = $(PORTSRC) \
        STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_hcd.c \
        usbh_midi_core.c \
        usbh_conf.c \
+       serial_midi.c \
        exceptions.c 
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global

--- a/firmware/midi.c
+++ b/firmware/midi.c
@@ -19,147 +19,59 @@
 #include "hal.h"
 #include "axoloti_board.h"
 #include "midi.h"
+#include "serial_midi.h"
 #include "patch.h"
 
-static unsigned char StatusLengthLookup[16] = {0, 0, 0, 0, 0, 0, 0, 0, 3, // 0x80=note off, 3 bytes
-                                               3, // 0x90=note on, 3 bytes
-                                               3, // 0xa0=poly pressure, 3 bytes
-                                               3, // 0xb0=control change, 3 bytes
-                                               2, // 0xc0=program change, 2 bytes
-                                               2, // 0xd0=channel pressure, 2 bytes
-                                               3, // 0xe0=pitch bend, 3 bytes
-                                               -1 // 0xf0=other things. may vary.
-    };
 
-const signed char SysMsgLengthLookup[16] = {-1, // 0xf0=sysex start. may vary
-    2, // 0xf1=MIDI Time Code. 2 bytes
-    3, // 0xf2=MIDI Song position. 3 bytes
-    2, // 0xf3=MIDI Song Select. 2 bytes.
-    1, // 0xf4=undefined
-    1, // 0xf5=undefined
-    1, // 0xf6=TUNE Request
-    1, // 0xf7=sysex end.
-    1, // 0xf8=timing clock. 1 byte
-    1, // 0xf9=proposed measure end?
-    1, // 0xfa=start. 1 byte
-    1, // 0xfb=continue. 1 byte
-    1, // 0xfc=stop. 1 byte
-    1, // 0xfd=undefined
-    1, // 0xfe=active sensing. 1 byte
-    3 // 0xff= not reset, but a META-EVENT, which is always 3 bytes
-    };
-
-unsigned char MidiByte0;
-unsigned char MidiByte1;
-unsigned char MidiByte2;
-unsigned char MidiCurData;
-unsigned char MidiNumData;
-unsigned char MidiInChannel;
-
-void MidiInByteHandler(uint8_t data) {
-  int8_t len;
-  if (data & 0x80) {
-    len = StatusLengthLookup[data >> 4];
-    if (len == -1) {
-      len = SysMsgLengthLookup[data - 0xF0];
-      if (len == 1) {
-        MidiInMsgHandler(data, 0, 0);
-      }
-      else {
-        MidiByte0 = data;
-        MidiNumData = len - 1;
-        MidiCurData = 0;
-      }
+void MidiSend1(midi_device_t dev,  __attribute__((__unused__)) uint8_t   port, uint8_t b0) {
+    switch (dev) {
+        case MIDI_DEVICE_SERIAL: {
+            serial_MidiSend1(b0);
+            break;
+        }
+        case MIDI_DEVICE_USB_HOST: {
+            usbh_MidiSend1(port, b0);
+            break;
+        }
+        default: {
+            // nop
+        }
     }
-    else {
-      MidiByte0 = data;
-      MidiNumData = len - 1;
-      MidiCurData = 0;
+}
+
+void MidiSend2(midi_device_t dev,  __attribute__((__unused__)) uint8_t port, uint8_t b0, uint8_t b1) {
+    switch (dev) {
+        case MIDI_DEVICE_SERIAL: {
+            serial_MidiSend2(b0,b1);
+            break;
+        }
+        case MIDI_DEVICE_USB_HOST: {
+            usbh_MidiSend2(port, b0,b1);
+            break;
+        }
+        default: {
+            // nop
+        }
     }
-  }
-  else // not a status byte
-  {
-    if (MidiCurData == 0) {
-      MidiByte1 = data;
-      if (MidiNumData == 1) {
-        // 2 byte message complete
-        MidiInMsgHandler(MidiByte0, MidiByte1, 0);
-        MidiCurData = 0;
-      }
-      else
-        MidiCurData++;
+}
+
+void MidiSend3(midi_device_t dev,  __attribute__((__unused__)) uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2) {
+    switch (dev) {
+        case MIDI_DEVICE_SERIAL: {
+            serial_MidiSend3(b0,b1,b2);
+            break;
+        }
+        case MIDI_DEVICE_USB_HOST: {
+            usbh_MidiSend2(port, b0,b1);
+            break;
+        }
+        default: {
+            // nop
+        }
     }
-    else if (MidiCurData == 1) {
-      MidiByte2 = data;
-      if (MidiNumData == 2) {
-        MidiInMsgHandler(MidiByte0, MidiByte1, MidiByte2);
-        MidiCurData = 0;
-      }
-    }
-  }
-}
-
-// Midi OUT
-
-void MidiSend1(uint8_t b0) {
-  sdPut(&SDMIDI, b0);
-}
-
-void MidiSend2(uint8_t b0, uint8_t b1) {
-  unsigned char tx[2];
-  tx[0] = b0;
-  tx[1] = b1;
-  sdWrite(&SDMIDI, tx, 2);
-}
-
-void MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2) {
-  unsigned char tx[3];
-  tx[0] = b0;
-  tx[1] = b1;
-  tx[2] = b2;
-  sdWrite(&SDMIDI, tx, 3);
-}
-
-int MidiGetOutputBufferPending(void) {
-  return chOQGetFullI(&SDMIDI.oqueue);
-}
-
-// Midi UART...
-static const SerialConfig sdMidiCfg = {31250, // baud
-    0, 0, 0};
-
-static WORKING_AREA(waThreadMidi, 256) __attribute__ ((section (".ccmramend")));
-
-__attribute__((noreturn))
-  static msg_t ThreadMidi(void *arg) {
-  (void)arg;
-#if CH_USE_REGISTRY
-  chRegSetThreadName("midi");
-#endif
-  while (1) {
-    char ch;
-    ch = sdGet(&SDMIDI);
-    MidiInByteHandler(ch);
-  }
 }
 
 void midi_init(void) {
-  /*
-   * Activates the serial driver 2 using the driver default configuration.
-   * PA2(TX) and PA3(RX) are routed to USART2.
-   */
-#ifdef BOARD_AXOLOTI_V05
-  // RX
-  palSetPadMode(GPIOG, 9, PAL_MODE_ALTERNATE(8) | PAL_MODE_INPUT_PULLUP);
-  // TX
-  palSetPadMode(GPIOG, 14, PAL_MODE_ALTERNATE(8) | PAL_STM32_OTYPE_OPENDRAIN);
-#else
-  // RX
-  palSetPadMode(GPIOB, 7, PAL_MODE_ALTERNATE(7)|PAL_MODE_INPUT_PULLUP);
-  // TX
-  palSetPadMode(GPIOB, 6, PAL_MODE_ALTERNATE(7)|PAL_STM32_OTYPE_OPENDRAIN);
-#endif
-  sdStart(&SDMIDI, &sdMidiCfg);
-  chThdCreateStatic(waThreadMidi, sizeof(waThreadMidi), NORMALPRIO, ThreadMidi,
-                    NULL);
+    serial_midi_init();
+    usbh_midi_init();
 }

--- a/firmware/midi.c
+++ b/firmware/midi.c
@@ -63,7 +63,7 @@ void MidiSend3(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, uint8_t 
             break;
         }
         case MIDI_DEVICE_USB_HOST: {
-            usbh_MidiSend2(port, b0,b1);
+            usbh_MidiSend3(port,b0,b1,b2);
             break;
         }
         default: {

--- a/firmware/midi.c
+++ b/firmware/midi.c
@@ -24,7 +24,7 @@
 #include "patch.h"
 
 
-void MidiSend1(midi_device_t dev,  __attribute__((__unused__)) uint8_t   port, uint8_t b0) {
+void MidiSend1(midi_device_t dev, uint8_t   port, uint8_t b0) {
     switch (dev) {
         case MIDI_DEVICE_SERIAL: {
             serial_MidiSend1(b0);
@@ -40,7 +40,7 @@ void MidiSend1(midi_device_t dev,  __attribute__((__unused__)) uint8_t   port, u
     }
 }
 
-void MidiSend2(midi_device_t dev,  __attribute__((__unused__)) uint8_t port, uint8_t b0, uint8_t b1) {
+void MidiSend2(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1) {
     switch (dev) {
         case MIDI_DEVICE_SERIAL: {
             serial_MidiSend2(b0,b1);
@@ -56,7 +56,7 @@ void MidiSend2(midi_device_t dev,  __attribute__((__unused__)) uint8_t port, uin
     }
 }
 
-void MidiSend3(midi_device_t dev,  __attribute__((__unused__)) uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2) {
+void MidiSend3(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2) {
     switch (dev) {
         case MIDI_DEVICE_SERIAL: {
             serial_MidiSend3(b0,b1,b2);

--- a/firmware/midi.c
+++ b/firmware/midi.c
@@ -20,6 +20,7 @@
 #include "axoloti_board.h"
 #include "midi.h"
 #include "serial_midi.h"
+#include "usbh_midi_core.h"
 #include "patch.h"
 
 
@@ -75,3 +76,21 @@ void midi_init(void) {
     serial_midi_init();
     usbh_midi_init();
 }
+
+
+int  MidiGetOutputBufferPending(midi_device_t dev)
+{
+    switch (dev) {
+        case MIDI_DEVICE_SERIAL: {
+            return serial_MidiGetOutputBufferPending();
+        }
+        case MIDI_DEVICE_USB_HOST: {
+            return usbh_MidiGetOutputBufferPending();
+        }
+        default: {
+            // nop
+            return 0;
+        }
+    }
+}
+

--- a/firmware/midi.h
+++ b/firmware/midi.h
@@ -94,12 +94,25 @@
 #define MIDI_C_OMNI_ON			0x7d // omni on all notes off
 #define MIDI_C_MONO				0x7e // mono on all notes off
 #define MIDI_C_POLY				0x7f // poly on all notes off
+
+typedef enum
+{
+    MIDI_DEVICE_OMNI=0,          // for filtering
+    MIDI_DEVICE_SERIAL,          // MIDI_DIN
+    MIDI_DEVICE_USB_DEVICE,      // MicroUSB  (currently used in pconnection, as midi over serial */
+    MIDI_DEVICE_USB_HOST,        // USB host port
+    MIDI_DEVICE_DIGITAL_X1,      // x1 pins
+    MIDI_DEVICE_DIGITAL_X2       // x2 pins
+} midi_device_t ;
+
+// midi port, from 1  = OMNI for filtering
+#define MIDI_PORT_OMNI 0
+
 void midi_init(void);
-void MidiInByteHandler(uint8_t data);
-void MidiInMsgHandler(uint8_t b0, uint8_t b1, uint8_t b2);
-void MidiSend1(uint8_t b0);
-void MidiSend2(uint8_t b0, uint8_t b1);
-void MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2);
-int MidiGetOutputBufferPending(void);
+void MidiInMsgHandler(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
+void MidiSend1(midi_device_t dev, uint8_t port, uint8_t b0);
+void MidiSend2(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1);
+void MidiSend3(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
+
 
 #endif

--- a/firmware/midi.h
+++ b/firmware/midi.h
@@ -97,7 +97,7 @@
 
 typedef enum
 {
-    MIDI_DEVICE_OMNI=0,          // for filtering
+    MIDI_DEVICE_OMNI=0,          // for filtering , and for 'internal' messages
     MIDI_DEVICE_SERIAL,          // MIDI_DIN
     MIDI_DEVICE_USB_DEVICE,      // MicroUSB  (currently used in pconnection, as midi over serial */
     MIDI_DEVICE_USB_HOST,        // USB host port
@@ -105,7 +105,7 @@ typedef enum
     MIDI_DEVICE_DIGITAL_X2       // x2 pins
 } midi_device_t ;
 
-// midi port, from 1  = OMNI for filtering
+// midi port, from 1  = OMNI for filtering and internal messages
 #define MIDI_PORT_OMNI 0
 
 void midi_init(void);
@@ -113,6 +113,9 @@ void MidiInMsgHandler(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, u
 void MidiSend1(midi_device_t dev, uint8_t port, uint8_t b0);
 void MidiSend2(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1);
 void MidiSend3(midi_device_t dev, uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
+
+// Note: this is used by a patcher, but is incorrect since it would need to know for which device
+int  MidiGetOutputBufferPending(midi_device_t dev);
 
 
 #endif

--- a/firmware/patch.c
+++ b/firmware/patch.c
@@ -21,6 +21,8 @@
 #include "sdcard.h"
 #include "string.h"
 #include "axoloti_board.h"
+#include "midi.h"
+
 
 patchMeta_t patchMeta;
 
@@ -148,9 +150,9 @@ void computebufI(int32_t *inp, int32_t *outp) {
     }
 }
 
-void MidiInMsgHandler(uint8_t status, uint8_t data1, uint8_t data2) {
+void MidiInMsgHandler(midi_device_t  dev, uint8_t port, uint8_t status, uint8_t data1, uint8_t data2) {
   if (!patchStatus) {
-    (patchMeta.fptr_MidiInHandler)(status, data1, data2);
+    (patchMeta.fptr_MidiInHandler)(dev, port, status, data1, data2);
   }
 }
 

--- a/firmware/patch.h
+++ b/firmware/patch.h
@@ -23,11 +23,12 @@
 #include "ui.h"
 #include "axoloti_board.h"
 #include "ff.h"
+#include "midi.h"
 
 typedef void (*fptr_patch_init_t)(int32_t fwID);
 typedef void (*fptr_patch_dispose_t)(void);
 typedef void (*fptr_patch_dsp_process_t)(int32_t *, int32_t *);
-typedef void (*fptr_patch_midi_in_handler_t)(uint8_t, uint8_t, uint8_t);
+typedef void (*fptr_patch_midi_in_handler_t)(midi_device_t dev, uint8_t port, uint8_t, uint8_t, uint8_t);
 typedef void (*fptr_patch_applyPreset_t)(int32_t);
 
 typedef struct {
@@ -69,6 +70,7 @@ void InitPatch0(void);
 void StartPatch(void);
 void StopPatch(void);
 
+/* USUSED?
 void PatchProcess(int16_t * inbuf, int16_t * outbuf);
 void PatchInit(void);
 void PatchMidiInNoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
@@ -85,6 +87,7 @@ void MidiInPitchBend(uint8_t channel, uint8_t data1, uint8_t data2);
 void MidiInPitchBend(uint8_t channel, uint8_t data1, uint8_t data2);
 void PatchMidiInAllNotesOff(uint8_t channel);
 void PatchMidiInResetControllers(uint8_t channel);
+*/
 
 #define PATCHMAINLOC 0x20010000
 

--- a/firmware/pconnection.c
+++ b/firmware/pconnection.c
@@ -676,7 +676,7 @@ void PExReceiveByte(unsigned char c) {
       break;
     case 6:
       midi_r[2] = c;
-      MidiInMsgHandler(midi_r[0], midi_r[1], midi_r[2]);
+      MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE,1,midi_r[0], midi_r[1], midi_r[2]);
       header = 0;
       state = 0;
       break;

--- a/firmware/serial_midi.c
+++ b/firmware/serial_midi.c
@@ -124,11 +124,9 @@ void serial_MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2) {
   sdWrite(&SDMIDI, tx, 3);
 }
 
-/* unused?
 int serial_MidiGetOutputBufferPending(void) {
   return chOQGetFullI(&SDMIDI.oqueue);
 }
- */
 
 // Midi UART...
 static const SerialConfig sdMidiCfg = {31250, // baud

--- a/firmware/serial_midi.c
+++ b/firmware/serial_midi.c
@@ -67,7 +67,7 @@ void serial_MidiInByteHandler(uint8_t data) {
     if (len == -1) {
       len = SysMsgLengthLookup[data - 0xF0];
       if (len == 1) {
-        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, data, 0, 0);
+        MidiInMsgHandler(MIDI_DEVICE_SERIAL, 1, data, 0, 0);
       }
       else {
         MidiByte0 = data;
@@ -87,7 +87,7 @@ void serial_MidiInByteHandler(uint8_t data) {
       MidiByte1 = data;
       if (MidiNumData == 1) {
         // 2 byte message complete
-        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, MidiByte0, MidiByte1, 0);
+        MidiInMsgHandler(MIDI_DEVICE_SERIAL, 1, MidiByte0, MidiByte1, 0);
         MidiCurData = 0;
       }
       else
@@ -96,7 +96,7 @@ void serial_MidiInByteHandler(uint8_t data) {
     else if (MidiCurData == 1) {
       MidiByte2 = data;
       if (MidiNumData == 2) {
-        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, MidiByte0, MidiByte1, MidiByte2);
+        MidiInMsgHandler(MIDI_DEVICE_SERIAL, 1, MidiByte0, MidiByte1, MidiByte2);
         MidiCurData = 0;
       }
     }

--- a/firmware/serial_midi.c
+++ b/firmware/serial_midi.c
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2013, 2014 Johannes Taelman
+ *
+ * This file is part of Axoloti.
+ *
+ * Axoloti is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Axoloti is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Axoloti. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "ch.h"
+#include "hal.h"
+#include "axoloti_board.h"
+#include "midi.h"
+#include "serial_midi.h"
+#include "patch.h"
+
+static unsigned char StatusLengthLookup[16] = {0, 0, 0, 0, 0, 0, 0, 0, 3, // 0x80=note off, 3 bytes
+                                               3, // 0x90=note on, 3 bytes
+                                               3, // 0xa0=poly pressure, 3 bytes
+                                               3, // 0xb0=control change, 3 bytes
+                                               2, // 0xc0=program change, 2 bytes
+                                               2, // 0xd0=channel pressure, 2 bytes
+                                               3, // 0xe0=pitch bend, 3 bytes
+                                               -1 // 0xf0=other things. may vary.
+    };
+
+const signed char SysMsgLengthLookup[16] = {-1, // 0xf0=sysex start. may vary
+    2, // 0xf1=MIDI Time Code. 2 bytes
+    3, // 0xf2=MIDI Song position. 3 bytes
+    2, // 0xf3=MIDI Song Select. 2 bytes.
+    1, // 0xf4=undefined
+    1, // 0xf5=undefined
+    1, // 0xf6=TUNE Request
+    1, // 0xf7=sysex end.
+    1, // 0xf8=timing clock. 1 byte
+    1, // 0xf9=proposed measure end?
+    1, // 0xfa=start. 1 byte
+    1, // 0xfb=continue. 1 byte
+    1, // 0xfc=stop. 1 byte
+    1, // 0xfd=undefined
+    1, // 0xfe=active sensing. 1 byte
+    3 // 0xff= not reset, but a META-EVENT, which is always 3 bytes
+    };
+
+unsigned char MidiByte0;
+unsigned char MidiByte1;
+unsigned char MidiByte2;
+unsigned char MidiCurData;
+unsigned char MidiNumData;
+unsigned char MidiInChannel;
+
+void serial_MidiInByteHandler(uint8_t data);
+
+
+void serial_MidiInByteHandler(uint8_t data) {
+  int8_t len;
+  if (data & 0x80) {
+    len = StatusLengthLookup[data >> 4];
+    if (len == -1) {
+      len = SysMsgLengthLookup[data - 0xF0];
+      if (len == 1) {
+        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, data, 0, 0);
+      }
+      else {
+        MidiByte0 = data;
+        MidiNumData = len - 1;
+        MidiCurData = 0;
+      }
+    }
+    else {
+      MidiByte0 = data;
+      MidiNumData = len - 1;
+      MidiCurData = 0;
+    }
+  }
+  else // not a status byte
+  {
+    if (MidiCurData == 0) {
+      MidiByte1 = data;
+      if (MidiNumData == 1) {
+        // 2 byte message complete
+        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, MidiByte0, MidiByte1, 0);
+        MidiCurData = 0;
+      }
+      else
+        MidiCurData++;
+    }
+    else if (MidiCurData == 1) {
+      MidiByte2 = data;
+      if (MidiNumData == 2) {
+        MidiInMsgHandler(MIDI_DEVICE_USB_DEVICE, 1, MidiByte0, MidiByte1, MidiByte2);
+        MidiCurData = 0;
+      }
+    }
+  }
+}
+
+// Midi OUT
+
+void serial_MidiSend1(uint8_t b0) {
+  sdPut(&SDMIDI, b0);
+}
+
+void serial_MidiSend2(uint8_t b0, uint8_t b1) {
+  unsigned char tx[2];
+  tx[0] = b0;
+  tx[1] = b1;
+  sdWrite(&SDMIDI, tx, 2);
+}
+
+void serial_MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2) {
+  unsigned char tx[3];
+  tx[0] = b0;
+  tx[1] = b1;
+  tx[2] = b2;
+  sdWrite(&SDMIDI, tx, 3);
+}
+
+/* unused?
+int serial_MidiGetOutputBufferPending(void) {
+  return chOQGetFullI(&SDMIDI.oqueue);
+}
+ */
+
+// Midi UART...
+static const SerialConfig sdMidiCfg = {31250, // baud
+    0, 0, 0};
+
+static WORKING_AREA(waThreadMidi, 256) __attribute__ ((section (".ccmramend")));
+
+__attribute__((noreturn))
+  static msg_t ThreadMidi(void *arg) {
+  (void)arg;
+#if CH_USE_REGISTRY
+  chRegSetThreadName("midi");
+#endif
+  while (1) {
+    char ch;
+    ch = sdGet(&SDMIDI);
+    serial_MidiInByteHandler(ch);
+  }
+}
+
+void serial_midi_init(void) {
+  /*
+   * Activates the serial driver 2 using the driver default configuration.
+   * PA2(TX) and PA3(RX) are routed to USART2.
+   */
+#ifdef BOARD_AXOLOTI_V05
+  // RX
+  palSetPadMode(GPIOG, 9, PAL_MODE_ALTERNATE(8) | PAL_MODE_INPUT_PULLUP);
+  // TX
+  palSetPadMode(GPIOG, 14, PAL_MODE_ALTERNATE(8) | PAL_STM32_OTYPE_OPENDRAIN);
+#else
+  // RX
+  palSetPadMode(GPIOB, 7, PAL_MODE_ALTERNATE(7)|PAL_MODE_INPUT_PULLUP);
+  // TX
+  palSetPadMode(GPIOB, 6, PAL_MODE_ALTERNATE(7)|PAL_STM32_OTYPE_OPENDRAIN);
+#endif
+  sdStart(&SDMIDI, &sdMidiCfg);
+  chThdCreateStatic(waThreadMidi, sizeof(waThreadMidi), NORMALPRIO, ThreadMidi,
+                    NULL);
+}

--- a/firmware/serial_midi.h
+++ b/firmware/serial_midi.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013, 2014 Johannes Taelman
+ * Copyright (C) 2013, 2014, 2015 Johannes Taelman
  *
  * This file is part of Axoloti.
  *
@@ -15,26 +15,16 @@
  * You should have received a copy of the GNU General Public License along with
  * Axoloti. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __AXOLOTI_DEFINES_H
-#define __AXOLOTI_DEFINES_H
+#ifndef __SERIAL_MIDI_H
+#define __SERIAL_MIDI_H
 
 #include <stdint.h>
 
-#define PI_F 3.1415927f
-#define SAMPLERATE 48000
-#define BUFSIZE 16
-#define BUFSIZE_POW 4
-typedef int32_t int32buffer[BUFSIZE];
+void serial_midi_init(void);
+void serial_MidiSend1(uint8_t b0);
+void serial_MidiSend2(uint8_t b0, uint8_t b1);
+void serial_MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2);
 
-//#define BOARD_STM32F4DISCOVERY 1
-//#define BOARD_AXOLOTI_V03 1
-#define BOARD_AXOLOTI_V05 1
-
-#if (BOARD_STM32F4DISCOVERY)
-#elif (BOARD_AXOLOTI_V03)
-#elif (BOARD_AXOLOTI_V05)
-#else
-#error Must define board!
-#endif
+// int  serial_MidiGetOutputBufferPending(void);
 
 #endif

--- a/firmware/serial_midi.h
+++ b/firmware/serial_midi.h
@@ -25,6 +25,6 @@ void serial_MidiSend1(uint8_t b0);
 void serial_MidiSend2(uint8_t b0, uint8_t b1);
 void serial_MidiSend3(uint8_t b0, uint8_t b1, uint8_t b2);
 
-// int  serial_MidiGetOutputBufferPending(void);
+int  serial_MidiGetOutputBufferPending(void);
 
 #endif

--- a/firmware/usbh_conf.c
+++ b/firmware/usbh_conf.c
@@ -42,6 +42,18 @@ HCD_HandleTypeDef hHCD;
 #include "usbh_midi_core.h"
 #include "ch.h"
 
+
+#include "midi.h"
+
+//extern void MidiInMsgHandler(uint8_t status, uint8_t data1, uint8_t data2);
+
+//TODO: need incoming port number
+void MIDI_CB(uint8_t a,uint8_t b,uint8_t c,uint8_t d){
+    USBH_DbgLog("M %x - %x %x %x\r\n",a,b,c,d);
+    //  a= pkt header 0xF0 = cable number 0x0F=CIN
+    MidiInMsgHandler(MIDI_DEVICE_USB_HOST, ((a & 0xF0) >> 4)+ 1 ,b,c,d);
+}
+
 USBH_HandleTypeDef hUSBHost; /* USB Host handle */
 static void USBH_UserProcess(USBH_HandleTypeDef *pHost, uint8_t vId);
 
@@ -571,12 +583,6 @@ void USBH_HID_EventCallback(USBH_HandleTypeDef *phost) {
   }
 }
 
-extern void MidiInMsgHandler(uint8_t status, uint8_t data1, uint8_t data2);
-
-void MIDI_CB(uint8_t a,uint8_t b,uint8_t c,uint8_t d){
-  USBH_DbgLog("M %x %x %x %x\r\n",a,b,c,d);
-  MidiInMsgHandler(b,c,d);
-}
 
 #define PORT_IRQ_HANDLER(id) void id(void)
 #define CH_IRQ_HANDLER(id) PORT_IRQ_HANDLER(id)

--- a/firmware/usbh_midi_core.c
+++ b/firmware/usbh_midi_core.c
@@ -41,6 +41,28 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbh_midi_core.h"
 
+
+void usbh_midi_init(void)
+{
+    
+}
+
+void usbh_MidiSend1(uint8_t port, uint8_t b0)
+{
+    
+}
+
+void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1)
+{
+    
+}
+
+void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2)
+{
+    
+}
+
+
 /** @defgroup USBH_MIDI_CORE_Private_Variables
  * @{
  */

--- a/firmware/usbh_midi_core.c
+++ b/firmware/usbh_midi_core.c
@@ -37,42 +37,100 @@
 #include "usbh_midi_core.h"
 
 
+
+#define _USB_H_
+#include "ch.h"
+
+USB_Setup_TypeDef MIDI_Setup;
+
+#define RING_BUFFER_SIZE 16
+
+typedef struct
+{
+    uint8_t data[4];
+} MIDIEvent_t;
+
+
+// very simple ring buffer
+static struct {
+    MIDIEvent_t event[RING_BUFFER_SIZE];
+    uint8_t read_ptr;
+    uint8_t write_ptr;
+} send_ring_buffer;
+
+
+
 void usbh_midi_init(void)
 {
+    send_ring_buffer.read_ptr = send_ring_buffer.write_ptr = 0;
+}
+
+
+// the Send etc, work for everything except Sysex
+inline uint8_t calcDS(uint8_t b0) {
+    // this works for everything bar SysEx,
+    // for sysex you need to use 0x4-0x7 to pack messages
+    return (b0 & 0xF0 ) >> 4;
     
 }
 
-void usbh_MidiSend1(uint8_t port, uint8_t b0)
-{
-    
+inline uint8_t calcCIN(uint8_t port, uint8_t b0) {
+    uint8_t ds  = calcDS(b0);
+    uint8_t cin = ((( port - 1) & 0x0F) << 4)  | ds;
+    return cin;
 }
 
-void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1)
-{
+
+void usbh_MidiSend1(uint8_t port, uint8_t b0) {
+    uint8_t next = (send_ring_buffer.write_ptr+ 1) % RING_BUFFER_SIZE;
     
+    if(next == send_ring_buffer.read_ptr) {
+        USBH_ErrLog("usbh_MidiSend1 : ring buffer overflow");
+    }
+    
+    send_ring_buffer.event[next].data[0]=calcCIN(port, b0);
+    send_ring_buffer.event[next].data[1]=b0;
+    send_ring_buffer.event[next].data[2]=0;
+    send_ring_buffer.event[next].data[3]=0;
+    send_ring_buffer.write_ptr=next;
 }
 
-void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2)
-{
+void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1) {
+    uint8_t next = (send_ring_buffer.write_ptr+ 1) % RING_BUFFER_SIZE;
     
+    if(next == send_ring_buffer.read_ptr) {
+        USBH_ErrLog("usbh_MidiSend2 : ring buffer overflow");
+    }
+    
+    send_ring_buffer.event[next].data[0]=calcCIN(port, b0);
+    send_ring_buffer.event[next].data[1]=b0;
+    send_ring_buffer.event[next].data[2]=b1;
+    send_ring_buffer.event[next].data[3]=0;
+    send_ring_buffer.write_ptr=next;
 }
 
-int  usbh_MidiGetOutputBufferPending()
-{
+void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2) {
+    uint8_t next = (send_ring_buffer.write_ptr+ 1) % RING_BUFFER_SIZE;
+    
+    if(next == send_ring_buffer.read_ptr) {
+        USBH_ErrLog("usbh_MidiSend3 : ring buffer overflow");
+    }
+    
+    send_ring_buffer.event[next].data[0]=calcCIN(port, b0);
+    send_ring_buffer.event[next].data[1]=b0;
+    send_ring_buffer.event[next].data[2]=b1;
+    send_ring_buffer.event[next].data[3]=b2;
+    send_ring_buffer.write_ptr=next;
+}
+
+int  usbh_MidiGetOutputBufferPending(void) {
     return 0;
 }
 
 /** @defgroup USBH_MIDI_CORE_Private_Variables
  * @{
  */
-//extern USB_OTG_CORE_HANDLE USB_OTG_Core_dev;
 
-
-USB_Setup_TypeDef MIDI_Setup;
-
-
-#define _USB_H_
-#include "ch.h"
 
 
 
@@ -83,10 +141,9 @@ static USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost)
 static USBH_StatusTypeDef USBH_MIDI_ClassRequest(USBH_HandleTypeDef *phost);
 static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost);
 static USBH_StatusTypeDef USBH_MIDI_SOFProcess(USBH_HandleTypeDef *phost);
-//static void  USBH_MIDI_ParseHIDDesc (HID_DescTypeDef *desc, uint8_t *buf);
 
-USBH_ClassTypeDef  MIDI_Class =
-{
+
+USBH_ClassTypeDef  MIDI_Class = {
   "MID",
   USB_AUDIO_CLASS,
   USBH_MIDI_InterfaceInit,
@@ -99,6 +156,16 @@ USBH_ClassTypeDef  MIDI_Class =
 
 #define MIDI_MIN_POLL 2
 
+inline bool isValidInput(MIDI_HandleTypeDef* pH)
+{
+    return pH->input_valid;
+}
+
+inline bool isValidOutput(MIDI_HandleTypeDef* pH)
+{
+    return pH->output_valid;
+}
+
 /*-----------------------------------------------------------------------------------------*/
 /**
  * @brief  USBH_MIDI_InterfaceInit
@@ -109,181 +176,100 @@ USBH_ClassTypeDef  MIDI_Class =
  */
 static USBH_StatusTypeDef USBH_MIDI_InterfaceInit(USBH_HandleTypeDef *phost) {
 
-  USBH_StatusTypeDef status = USBH_FAIL;
-  MIDI_HandleTypeDef *MIDI_Handle;
+    USBH_StatusTypeDef status = USBH_FAIL;
+    MIDI_HandleTypeDef *MIDI_Handle;
 
-  uint8_t max_ep;
-  uint8_t num = 0;
-  uint8_t interface;
+    uint8_t interface;
+    send_ring_buffer.read_ptr = send_ring_buffer.write_ptr = 0;
 
-  for(interface=0; interface<phost->device.CfgDesc.bNumInterfaces && interface < USBH_MAX_NUM_INTERFACES; interface++) {
+    // this is limited to one midi interface, and also currently only 1 input and 1 output endpoint on that interface
+    
+    for(interface=0; interface<phost->device.CfgDesc.bNumInterfaces && interface < USBH_MAX_NUM_INTERFACES; interface++) {
+        if( (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceClass == USB_AUDIO_CLASS) &&
+            (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS) ) {
 
-      if( (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceClass == USB_AUDIO_CLASS) &&
-          (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS) ) {
-
+            // bizarre, why select the interface... all it does is put it in current interface and then log it,
+            // but we may not even actually use it !?
             USBH_SelectInterface(phost, interface);
             phost->pActiveClass->pData = (MIDI_HandleTypeDef *)USBH_malloc(sizeof(MIDI_HandleTypeDef));
             MIDI_Handle = phost->pActiveClass->pData;
-
             MIDI_Handle->state_in = MIDI_INIT;
-            MIDI_Handle->ep_addr = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress;
-            MIDI_Handle->poll = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bInterval;
+            MIDI_Handle->state_out = MIDI_INIT;
+
+
+            uint8_t num_ep = ((phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints <= USBH_MAX_NUM_ENDPOINTS)
+                              ? phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints
+                              : USBH_MAX_NUM_ENDPOINTS);
+
+            // eventually we should be looking for multiple input and output EP, for output we then just write to the one indicated
+            // by the CID, for READ we may have to consider allowing the user to select which ports they are interested in (for efficiency?)
+            // but for the moment just pick the first input and the first output
+            MIDI_Handle->input_valid = false;
+            MIDI_Handle->output_valid = false;
+
+            uint8_t i=0;
+            for (; i< num_ep && (!isValidInput(MIDI_Handle) || !isValidOutput(MIDI_Handle)) ; i++) {
+                
+                uint8_t iv = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].bInterval;
+                // select longest poll time
+                MIDI_Handle->poll = iv > MIDI_Handle->poll ? iv : MIDI_Handle->poll;
+
+
+                if(!isValidInput(MIDI_Handle) && phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].bEndpointAddress & 0x80) {
+                    MIDI_Handle->InEp = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].bEndpointAddress;
+                    MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].wMaxPacketSize;
+                    MIDI_Handle->input_valid = true;
+                }
+                if(!isValidOutput(MIDI_Handle) && phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].bEndpointAddress)
+                {
+                    MIDI_Handle->OutEp = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].bEndpointAddress;
+                    MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[i].wMaxPacketSize;
+                    MIDI_Handle->output_valid = true;
+                }
+                
+            } // each endpoint, or until ive found both input and output endpoint
 
             if (MIDI_Handle->poll < MIDI_MIN_POLL) {
                 MIDI_Handle->poll = MIDI_MIN_POLL;
             }
 
-            if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress & 0x80) {
-                MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
-                MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
+
+            if (isValidOutput(MIDI_Handle)) {
+                USBH_UsrLog("USB Host Output connected to %i : %i", interface, MIDI_Handle->OutEp );
+
+                MIDI_Handle->OutPipe = USBH_AllocPipe(phost, MIDI_Handle->OutEp);
+                USBH_OpenPipe  (phost,
+                                MIDI_Handle->OutPipe,
+                                MIDI_Handle->OutEp,
+                                phost->device.address,
+                                phost->device.speed,
+                                USB_EP_TYPE_BULK,
+                                MIDI_Handle->OutEpSize);
+                USBH_LL_SetToggle  (phost, MIDI_Handle->OutPipe,0);
             }
-            else {
-                MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
-                MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
+            
+            if (isValidInput(MIDI_Handle)) {
+                USBH_UsrLog("USB Host Input connected to %i : %i", interface, MIDI_Handle->InEp );
+
+                MIDI_Handle->InPipe = USBH_AllocPipe(phost, MIDI_Handle->InEp);
+                USBH_OpenPipe  (phost,
+                                MIDI_Handle->InPipe,
+                                MIDI_Handle->InEp,
+                                phost->device.address,
+                                phost->device.speed,
+                                USB_EP_TYPE_BULK,
+                                MIDI_Handle->InEpSize);
+                USBH_LL_SetToggle  (phost, MIDI_Handle->InPipe,0);
             }
-
-            if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress & 0x80) {
-                MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
-                MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
-            }
-            else {
-                MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
-                MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
-            }
-
-#if 0
-//    /* Check fo available number of endpoints */
-//    /* Find the number of EPs in the Interface Descriptor */
-//    /* Choose the lower number in order not to overrun the buffer allocated */
-//    max_ep =
-//        ((phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints
-//            <= USBH_MAX_NUM_ENDPOINTS) ? phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints :
-//                                         USBH_MAX_NUM_ENDPOINTS);
-//
-//    /* Decode endpoint IN and OUT address from interface descriptor */
-//    for (; num < max_ep; num++) {
-//      if (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress
-//          & 0x80) {
-//        MIDI_Handle->InEp =
-//            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
-//        MIDI_Handle->InPipe =\
-// USBH_AllocPipe(phost, MIDI_Handle->InEp);
-//
-//        /* Open pipe for IN endpoint */
-//        USBH_OpenPipe(phost, MIDI_Handle->InPipe, MIDI_Handle->InEp,
-//                      phost->device.address, phost->device.speed,
-//                      USB_EP_TYPE_BULK, MIDI_Handle->length);
-//
-//      }
-//#if 0
-//      else {
-//        MIDI_Handle->OutEp =
-//            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
-//        MIDI_Handle->OutPipe =\
-// USBH_AllocPipe(phost, MIDI_Handle->OutEp);
-//
-//        /* Open pipe for OUT endpoint */
-//        USBH_OpenPipe(phost, MIDI_Handle->OutPipe, MIDI_Handle->OutEp,
-//                      phost->device.address, phost->device.speed,
-//                      USB_EP_TYPE_BULK, MIDI_Handle->length);
-//      }
-//#endif
-//    }
-#endif
-
-            MIDI_Handle->OutPipe = USBH_AllocPipe(phost, MIDI_Handle->OutEp);
-            MIDI_Handle->InPipe = USBH_AllocPipe(phost, MIDI_Handle->InEp);
-          
-            /* Open the new channels */
-            USBH_OpenPipe  (phost,
-                            MIDI_Handle->OutPipe,
-                            MIDI_Handle->OutEp,
-                            phost->device.address,
-                            phost->device.speed,
-                            USB_EP_TYPE_BULK,
-                            MIDI_Handle->OutEpSize);
-
-            USBH_OpenPipe  (phost,
-                            MIDI_Handle->InPipe,
-                            MIDI_Handle->InEp,
-                            phost->device.address,
-                            phost->device.speed,
-                            USB_EP_TYPE_BULK,
-                            MIDI_Handle->InEpSize);
-
-
-            USBH_LL_SetToggle  (phost, MIDI_Handle->InPipe,0);
-            USBH_LL_SetToggle  (phost, MIDI_Handle->OutPipe,0);
-
-
             status = USBH_OK;
-      } // if, a midi interface
-  }// for each interface
+            return status;
+        } // if, a midi interface
+  
+    }// for each interface
     
   return status;
 }
-#if 0 // original code
-//if((phost->device_prop.Itf_Desc[0].bInterfaceClass == USB_AUDIO_CLASS) &&
-//    (pphost->device_prop.Itf_Desc[0].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS))
-//{
-//  if(phost->device_prop.Ep_Desc[0][0].bEndpointAddress & 0x80)
-//  {
-//    MIDI_Machine.MIDIBulkInEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
-//    MIDI_Machine.MIDIBulkInEpSize = phost->device_prop.Ep_Desc[0][0].wMaxPacketSize;
-//  }
-//  else
-//  {
-//    MIDI_Machine.MIDIBulkOutEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
-//    MIDI_Machine.MIDIBulkOutEpSize = phost->device_prop.Ep_Desc[0] [0].wMaxPacketSize;
-//  }
-//
-//  if(pphost->device_prop.Ep_Desc[0][1].bEndpointAddress & 0x80)
-//
-//  {
-//    MIDI_Machine.MIDIBulkInEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
-//    MIDI_Machine.MIDIBulkInEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
-//  }
-//  else
-//  {
-//    MIDI_Machine.MIDIBulkOutEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
-//    MIDI_Machine.MIDIBulkOutEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
-//  }
-//
-//  MIDI_Machine.hc_num_out = USBH_Alloc_Channel(pdev,
-//      MIDI_Machine.MIDIBulkOutEp);
-//  MIDI_Machine.hc_num_in = USBH_Alloc_Channel(pdev,
-//      MIDI_Machine.MIDIBulkInEp);
-//
-//  /* Open the new channels */
-//  USBH_Open_Channel (pdev,
-//      MIDI_Machine.hc_num_out,
-//      pphost->device_prop.address,
-//      pphost->device_prop.speed,
-//      EP_TYPE_BULK,
-//      MIDI_Machine.MIDIBulkOutEpSize);
-//
-//  USBH_Open_Channel (pdev,
-//      MIDI_Machine.hc_num_in,
-//      pphost->device_prop.address,
-//      pphost->device_prop.speed,
-//      EP_TYPE_BULK,
-//      MIDI_Machine.MIDIBulkInEpSize);
-//
-//  MIDI_Machine.state = MIDI_GET_DATA;
-//  start_toggle =0;
-//  status = USBH_OK;
-//
-//}
-//
-//else
-//{
-//  phost->
-//  usr_cb->DeviceNotSupported();
-//}
-//
-//return status;
-//}
-#endif
+
 
 /*-----------------------------------------------------------------------------------------*/
 /**
@@ -293,23 +279,20 @@ static USBH_StatusTypeDef USBH_MIDI_InterfaceInit(USBH_HandleTypeDef *phost) {
  * @param  hdev: Selected device property
  * @retval None
  */
-USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost) {
-#if 0
-//  if (MIDI_Machine.hc_num_out) {
-//    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_out);
-//    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_out);
-//    MIDI_Machine.hc_num_out = 0; /* Reset the Channel as Free */
-//  }
-//
-//  if (MIDI_Machine.hc_num_in) {
-//    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_in);
-//    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_in);
-//    MIDI_Machine.hc_num_in = 0; /* Reset the Channel as Free */
-//  }
-//  start_toggle = 0;
-#else
-  return USBH_OK;
-#endif
+USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (__attribute__((__unused__))  USBH_HandleTypeDef *phost) {
+//    if (isValidOutput(MIDI_Handle) {
+//        USB_OTG_HC_Halt(phost, MIDI_Handle->OutPipe);
+//        USBH_Free_Channel(phost, MIDI_Handle->OutPipe);
+//        MIDI_Handle->OutPipe = 0;
+//        MIDI_Handle->output_valid = false;
+//    }
+//    if (isValidInput(MIDI_Handle) {
+//        USB_OTG_HC_Halt(phost, MIDI_Handle->InPipe);
+//        USBH_Free_Channel(phost, MIDI_Handle->InPipe);
+//        MIDI_Handle->InPipe = 0;
+//        MIDI_Handle->input_valid = false;
+//    }
+    return USBH_OK;
 }
 /*-----------------------------------------------------------------------------------------*/
 /**
@@ -320,7 +303,7 @@ USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost) {
  * @param  hdev: Selected device property
  * @retval  USBH_Status :Response for USB Set Protocol request
  */
-static USBH_StatusTypeDef USBH_MIDI_ClassRequest(USBH_HandleTypeDef *phost) {
+static USBH_StatusTypeDef USBH_MIDI_ClassRequest(__attribute__((__unused__))  USBH_HandleTypeDef *phost) {
     USBH_StatusTypeDef status = USBH_OK;
 
     return status;
@@ -337,8 +320,10 @@ static USBH_StatusTypeDef USBH_MIDI_ClassRequest(USBH_HandleTypeDef *phost) {
 
 volatile USBH_URBStateTypeDef URB_state_in;
 volatile USBH_URBStateTypeDef URB_state_out;
-volatile int state_in;
-volatile int state_out;
+//volatile int state_in;
+//volatile int state_out;
+
+#define SEND_DATA_DO_PING 1
 
 static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost) {
     
@@ -346,56 +331,102 @@ static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost) {
     MIDI_HandleTypeDef *MIDI_Handle = phost->pActiveClass->pData;
     URB_state_in    = USBH_LL_GetURBState(phost, MIDI_Handle->InPipe);
     URB_state_out   = USBH_LL_GetURBState(phost, MIDI_Handle->OutPipe);
-    state_in        = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
-    state_out       = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
+//    state_in        = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
+//    state_out       = HAL_HCD_GetState(phost->pData, MIDI_Handle->OutPipe);
 
 
 //  if (HCD_IsDeviceConnected(pdev)) {
     //appliStatus = pphost->usr_cb->UserApplication(); // this will call USBH_USR_MIDI_Application()
 
     switch (MIDI_Handle->state_in) {
+        case MIDI_INIT:
+            MIDI_Handle->state_in = MIDI_GET_DATA;
+            break;
 
-    case MIDI_INIT:
-      MIDI_Handle->state_in = MIDI_GET_DATA;
-      break;
-
-    case MIDI_GET_DATA:
-        if (URB_state_in == USBH_URB_STALL) {
-            USBH_ClrFeature(phost, MIDI_Handle->InEp);
-        } else if (URB_state_in == USBH_URB_ERROR) {
-            USBH_ClrFeature(phost, MIDI_Handle->InEp);
-        }
-
-        USBH_BulkReceiveData(phost, MIDI_Handle->buff, USBH_MIDI_MPS_SIZE,
-                           MIDI_Handle->InPipe);
-        MIDI_Handle->state_in = MIDI_POLL;
-        //STM_EVAL_LEDOn(LED_Blue);
-        break;
-
-    case MIDI_POLL:
-        if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe) == USBH_URB_DONE) {
-            int i;
-            
-            int n = USBH_LL_GetLastXferSize(phost, MIDI_Handle->InPipe);
-            for (i=0;i<n;i+=4) {
-                MIDI_CB(MIDI_Handle->buff[0+i],MIDI_Handle->buff[1+i],MIDI_Handle->buff[2+i],MIDI_Handle->buff[3+i]);
+        case MIDI_GET_DATA:
+            if (URB_state_in == USBH_URB_STALL) {
+                USBH_ClrFeature(phost, MIDI_Handle->InEp);
+            } else if (URB_state_in == USBH_URB_ERROR) {
+                USBH_ClrFeature(phost, MIDI_Handle->InEp);
             }
+
+            USBH_BulkReceiveData(phost, MIDI_Handle->buff_in, USBH_MIDI_MPS_SIZE, MIDI_Handle->InPipe);
+            MIDI_Handle->state_in = MIDI_POLL;
+            //STM_EVAL_LEDOn(LED_Blue);
+            break;
+
+        case MIDI_POLL:
+            if (URB_state_in == USBH_URB_DONE) {
+                int i;
                 
-            MIDI_Handle->buff[1] = 0;
-            //        MIDI_Handle->state_in = MIDI_IDLE;
-            MIDI_Handle->timer = 0;
-        } // if DONE
-        else if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe)== USBH_URB_STALL) {/* IN Endpoint Stalled */
-            /* Issue Clear Feature on IN endpoint */
-            if (USBH_ClrFeature(phost, MIDI_Handle->InEp) == USBH_OK) {
-              /* Change state to issue next IN token */
-              MIDI_Handle->state_in = MIDI_GET_DATA;
-            }
-        } // if STALL
-        break;
+                int n = USBH_LL_GetLastXferSize(phost, MIDI_Handle->InPipe);
+                for (i=0; i<n; i+=4) {
+                    MIDI_CB(MIDI_Handle->buff_in[0+i],MIDI_Handle->buff_in[1+i],MIDI_Handle->buff_in[2+i],MIDI_Handle->buff_in[3+i]);
+                }
+                    
+                MIDI_Handle->buff_in[1] = 0;
+                // MIDI_Handle->state_in = MIDI_IDLE;
+                MIDI_Handle->timer = 0;
+                
+            } else if (URB_state_in == USBH_URB_STALL) {
+                /* IN Endpoint Stalled */
+                /* Issue Clear Feature on IN endpoint */
+                if (USBH_ClrFeature(phost, MIDI_Handle->InEp) == USBH_OK) {
+                    /* Change state to issue next IN token */
+                    MIDI_Handle->state_in = MIDI_GET_DATA;
+                }
+            } // if STALL
+            break;
 
-    default:
-        break;
+        default:
+            break;
+    } // case
+
+    switch (MIDI_Handle->state_out)
+    {
+        case MIDI_INIT:
+            MIDI_Handle->state_out = MIDI_SEND_DATA;
+            break;
+            
+        case MIDI_SEND_DATA:
+            
+            if (send_ring_buffer.read_ptr != send_ring_buffer.write_ptr)
+            {
+                send_ring_buffer.read_ptr =(send_ring_buffer.read_ptr + 1) % RING_BUFFER_SIZE;
+                USBH_DbgLog("USB Host Output sending data @ %i", send_ring_buffer.read_ptr  );
+
+                USBH_DbgLog("USB Host Output sending data : %x, %x, %x %x",
+                            send_ring_buffer.event[send_ring_buffer.read_ptr].data[0],
+                            send_ring_buffer.event[send_ring_buffer.read_ptr].data[1],
+                            send_ring_buffer.event[send_ring_buffer.read_ptr].data[2],
+                            send_ring_buffer.event[send_ring_buffer.read_ptr].data[3]);
+                
+                MIDI_Handle->buff_out[0] =  send_ring_buffer.event[send_ring_buffer.read_ptr].data[0];
+                MIDI_Handle->buff_out[1] =  send_ring_buffer.event[send_ring_buffer.read_ptr].data[1];
+                MIDI_Handle->buff_out[2] =  send_ring_buffer.event[send_ring_buffer.read_ptr].data[2];
+                MIDI_Handle->buff_out[3] =  send_ring_buffer.event[send_ring_buffer.read_ptr].data[3];
+
+                USBH_BulkSendData(phost, MIDI_Handle->buff_out, 4, MIDI_Handle->OutPipe, SEND_DATA_DO_PING);
+                
+                // now poll for completion
+                MIDI_Handle->state_out = MIDI_POLL;
+            }
+            
+            break;
+        case MIDI_POLL:
+            if(URB_state_out == USBH_URB_DONE) {
+                USBH_DbgLog("USB Host Output  URB DONE");
+                MIDI_Handle->state_out = MIDI_SEND_DATA;
+            }
+            else if(URB_state_out == USBH_URB_NOTREADY) {
+                USBH_DbgLog("USB Host Output  NOT READY");
+                // check this, sound like send is not complete, i.e. should re-poll
+                MIDI_Handle->state_out = MIDI_SEND_DATA;
+            }
+            break;
+            
+        default:
+            break;
     } // case
     
     return status;
@@ -405,9 +436,9 @@ static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost) {
 static USBH_StatusTypeDef USBH_MIDI_SOFProcess(USBH_HandleTypeDef *phost) {
     MIDI_HandleTypeDef *MIDI_Handle =  (MIDI_HandleTypeDef *) phost->pActiveClass->pData;
 
-    if(MIDI_Handle->state_in == MIDI_POLL) {
-        if(( phost->Timer - MIDI_Handle->timer) >= MIDI_Handle->poll)
-        {
+    // this needs tidying up
+    if(MIDI_Handle->state_in == MIDI_POLL ) { // || MIDI_Handle->state_out == MIDI_POLL ) {
+        if(( phost->Timer - MIDI_Handle->timer) >= MIDI_Handle->poll) {
             MIDI_Handle->state_in = MIDI_GET_DATA;
             #if (USBH_USE_OS == 1)
             osMessagePutI ( phost->os_event, USBH_URB_EVENT, 0);
@@ -416,24 +447,3 @@ static USBH_StatusTypeDef USBH_MIDI_SOFProcess(USBH_HandleTypeDef *phost) {
     }
     return USBH_OK;
 }
-
-/* Receive data from MIDI device *//*
-uint8_t MIDI_RcvData(uint8_t *outBuf) {
-URB_STATE urb_status;
-urb_status = HCD_GetURB_State(&USB_OTG_Core_dev, MIDI_Machine.hc_num_in);
-
-if (urb_status <= URB_DONE) {
-  USBH_BulkReceiveData(&USB_OTG_Core_dev, MIDI_Machine.buff, 64,
-                       MIDI_Machine.hc_num_in);
-  if (MIDI_Machine.buff[0] == 0 && MIDI_Machine.buff[1] == 0
-      && MIDI_Machine.buff[2] == 0 && MIDI_Machine.buff[3] == 0)
-    return 0;
-  outBuf[0] = MIDI_Machine.buff[1];
-  outBuf[1] = MIDI_Machine.buff[2];
-  outBuf[2] = MIDI_Machine.buff[3];
-  return MIDI_lookupMsgSize(MIDI_Machine.buff[1]);
-}
-else
-  return 0;
-
-}*/

--- a/firmware/usbh_midi_core.c
+++ b/firmware/usbh_midi_core.c
@@ -402,7 +402,6 @@ static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost) {
             if (send_ring_buffer.read_ptr != send_ring_buffer.write_ptr)
             {
                 send_ring_buffer.read_ptr =(send_ring_buffer.read_ptr + 1) % RING_BUFFER_SIZE;
-                USBH_UsrLog("USB Host Output sending data @ %i", send_ring_buffer.read_ptr  );
                 USBH_DbgLog("USB Host Output sending data @ %i", send_ring_buffer.read_ptr  );
 
                 USBH_DbgLog("USB Host Output sending data : %x, %x, %x %x",

--- a/firmware/usbh_midi_core.c
+++ b/firmware/usbh_midi_core.c
@@ -8,12 +8,7 @@
  *
  * @verbatim
  *
- *          ===================================================================
- *                                MIDI Class  Description
- *          ===================================================================
- *
- *
- *  @endverbatim
+ * @endverbatim
  *
  ******************************************************************************
  *
@@ -123,177 +118,171 @@ static USBH_StatusTypeDef USBH_MIDI_InterfaceInit(USBH_HandleTypeDef *phost) {
 
   for(interface=0; interface<phost->device.CfgDesc.bNumInterfaces && interface < USBH_MAX_NUM_INTERFACES; interface++) {
 
-  if( (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceClass == USB_AUDIO_CLASS) &&
-      (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS) ) {
+      if( (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceClass == USB_AUDIO_CLASS) &&
+          (phost->device.CfgDesc.Itf_Desc[interface].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS) ) {
 
-    USBH_SelectInterface(phost, interface);
-    phost->pActiveClass->pData = (MIDI_HandleTypeDef *)USBH_malloc(
-        sizeof(MIDI_HandleTypeDef));
-    MIDI_Handle = phost->pActiveClass->pData;
+            USBH_SelectInterface(phost, interface);
+            phost->pActiveClass->pData = (MIDI_HandleTypeDef *)USBH_malloc(sizeof(MIDI_HandleTypeDef));
+            MIDI_Handle = phost->pActiveClass->pData;
 
-    MIDI_Handle->state = MIDI_INIT;
-    MIDI_Handle->ep_addr =
-        phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress;
-    MIDI_Handle->poll =
-        phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bInterval;
+            MIDI_Handle->state_in = MIDI_INIT;
+            MIDI_Handle->ep_addr = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress;
+            MIDI_Handle->poll = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bInterval;
 
-    if (MIDI_Handle->poll < MIDI_MIN_POLL) {
-      MIDI_Handle->poll = MIDI_MIN_POLL;
-    }
+            if (MIDI_Handle->poll < MIDI_MIN_POLL) {
+                MIDI_Handle->poll = MIDI_MIN_POLL;
+            }
 
-    if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress & 0x80)
-    {
-      MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
-      MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
-    }
-    else
-    {
-      MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
-      MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
-    }
+            if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress & 0x80) {
+                MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
+                MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
+            }
+            else {
+                MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].bEndpointAddress);
+                MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[0].wMaxPacketSize;
+            }
 
-    if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress & 0x80)
-    {
-      MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
-      MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
-    }
-    else
-    {
-      MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
-      MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
-    }
+            if(phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress & 0x80) {
+                MIDI_Handle->InEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
+                MIDI_Handle->InEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
+            }
+            else {
+                MIDI_Handle->OutEp = (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].bEndpointAddress);
+                MIDI_Handle->OutEpSize  = phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[1].wMaxPacketSize;
+            }
 
 #if 0
-    /* Check fo available number of endpoints */
-    /* Find the number of EPs in the Interface Descriptor */
-    /* Choose the lower number in order not to overrun the buffer allocated */
-    max_ep =
-        ((phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints
-            <= USBH_MAX_NUM_ENDPOINTS) ? phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints :
-                                         USBH_MAX_NUM_ENDPOINTS);
-
-    /* Decode endpoint IN and OUT address from interface descriptor */
-    for (; num < max_ep; num++) {
-      if (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress
-          & 0x80) {
-        MIDI_Handle->InEp =
-            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
-        MIDI_Handle->InPipe =\
- USBH_AllocPipe(phost, MIDI_Handle->InEp);
-
-        /* Open pipe for IN endpoint */
-        USBH_OpenPipe(phost, MIDI_Handle->InPipe, MIDI_Handle->InEp,
-                      phost->device.address, phost->device.speed,
-                      USB_EP_TYPE_BULK, MIDI_Handle->length);
-
-      }
-#if 0
-      else {
-        MIDI_Handle->OutEp =
-            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
-        MIDI_Handle->OutPipe =\
- USBH_AllocPipe(phost, MIDI_Handle->OutEp);
-
-        /* Open pipe for OUT endpoint */
-        USBH_OpenPipe(phost, MIDI_Handle->OutPipe, MIDI_Handle->OutEp,
-                      phost->device.address, phost->device.speed,
-                      USB_EP_TYPE_BULK, MIDI_Handle->length);
-      }
+//    /* Check fo available number of endpoints */
+//    /* Find the number of EPs in the Interface Descriptor */
+//    /* Choose the lower number in order not to overrun the buffer allocated */
+//    max_ep =
+//        ((phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints
+//            <= USBH_MAX_NUM_ENDPOINTS) ? phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].bNumEndpoints :
+//                                         USBH_MAX_NUM_ENDPOINTS);
+//
+//    /* Decode endpoint IN and OUT address from interface descriptor */
+//    for (; num < max_ep; num++) {
+//      if (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress
+//          & 0x80) {
+//        MIDI_Handle->InEp =
+//            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
+//        MIDI_Handle->InPipe =\
+// USBH_AllocPipe(phost, MIDI_Handle->InEp);
+//
+//        /* Open pipe for IN endpoint */
+//        USBH_OpenPipe(phost, MIDI_Handle->InPipe, MIDI_Handle->InEp,
+//                      phost->device.address, phost->device.speed,
+//                      USB_EP_TYPE_BULK, MIDI_Handle->length);
+//
+//      }
+//#if 0
+//      else {
+//        MIDI_Handle->OutEp =
+//            (phost->device.CfgDesc.Itf_Desc[phost->device.current_interface].Ep_Desc[num].bEndpointAddress);
+//        MIDI_Handle->OutPipe =\
+// USBH_AllocPipe(phost, MIDI_Handle->OutEp);
+//
+//        /* Open pipe for OUT endpoint */
+//        USBH_OpenPipe(phost, MIDI_Handle->OutPipe, MIDI_Handle->OutEp,
+//                      phost->device.address, phost->device.speed,
+//                      USB_EP_TYPE_BULK, MIDI_Handle->length);
+//      }
+//#endif
+//    }
 #endif
-    }
-#endif
 
-    MIDI_Handle->OutPipe = USBH_AllocPipe(phost, MIDI_Handle->OutEp);
-    MIDI_Handle->InPipe = USBH_AllocPipe(phost, MIDI_Handle->InEp);
-    /* Open the new channels */
-    USBH_OpenPipe  (phost,
-                    MIDI_Handle->OutPipe,
-                    MIDI_Handle->OutEp,
-                    phost->device.address,
-                    phost->device.speed,
-                    USB_EP_TYPE_BULK,
-                    MIDI_Handle->OutEpSize);
+            MIDI_Handle->OutPipe = USBH_AllocPipe(phost, MIDI_Handle->OutEp);
+            MIDI_Handle->InPipe = USBH_AllocPipe(phost, MIDI_Handle->InEp);
+          
+            /* Open the new channels */
+            USBH_OpenPipe  (phost,
+                            MIDI_Handle->OutPipe,
+                            MIDI_Handle->OutEp,
+                            phost->device.address,
+                            phost->device.speed,
+                            USB_EP_TYPE_BULK,
+                            MIDI_Handle->OutEpSize);
 
-    USBH_OpenPipe  (phost,
-                    MIDI_Handle->InPipe,
-                    MIDI_Handle->InEp,
-                    phost->device.address,
-                    phost->device.speed,
-                    USB_EP_TYPE_BULK,
-                    MIDI_Handle->InEpSize);
-
-
-    USBH_LL_SetToggle  (phost, MIDI_Handle->InPipe,0);
-    USBH_LL_SetToggle  (phost, MIDI_Handle->OutPipe,0);
+            USBH_OpenPipe  (phost,
+                            MIDI_Handle->InPipe,
+                            MIDI_Handle->InEp,
+                            phost->device.address,
+                            phost->device.speed,
+                            USB_EP_TYPE_BULK,
+                            MIDI_Handle->InEpSize);
 
 
-    status = USBH_OK;
-  }
-  }
+            USBH_LL_SetToggle  (phost, MIDI_Handle->InPipe,0);
+            USBH_LL_SetToggle  (phost, MIDI_Handle->OutPipe,0);
+
+
+            status = USBH_OK;
+      } // if, a midi interface
+  }// for each interface
+    
   return status;
 }
 #if 0 // original code
-if((phost->device_prop.Itf_Desc[0].bInterfaceClass == USB_AUDIO_CLASS) &&
-    (pphost->device_prop.Itf_Desc[0].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS))
-{
-  if(phost->device_prop.Ep_Desc[0][0].bEndpointAddress & 0x80)
-  {
-    MIDI_Machine.MIDIBulkInEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
-    MIDI_Machine.MIDIBulkInEpSize = phost->device_prop.Ep_Desc[0][0].wMaxPacketSize;
-  }
-  else
-  {
-    MIDI_Machine.MIDIBulkOutEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
-    MIDI_Machine.MIDIBulkOutEpSize = phost->device_prop.Ep_Desc[0] [0].wMaxPacketSize;
-  }
-
-  if(pphost->device_prop.Ep_Desc[0][1].bEndpointAddress & 0x80)
-
-  {
-    MIDI_Machine.MIDIBulkInEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
-    MIDI_Machine.MIDIBulkInEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
-  }
-  else
-  {
-    MIDI_Machine.MIDIBulkOutEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
-    MIDI_Machine.MIDIBulkOutEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
-  }
-
-  MIDI_Machine.hc_num_out = USBH_Alloc_Channel(pdev,
-      MIDI_Machine.MIDIBulkOutEp);
-  MIDI_Machine.hc_num_in = USBH_Alloc_Channel(pdev,
-      MIDI_Machine.MIDIBulkInEp);
-
-  /* Open the new channels */
-  USBH_Open_Channel (pdev,
-      MIDI_Machine.hc_num_out,
-      pphost->device_prop.address,
-      pphost->device_prop.speed,
-      EP_TYPE_BULK,
-      MIDI_Machine.MIDIBulkOutEpSize);
-
-  USBH_Open_Channel (pdev,
-      MIDI_Machine.hc_num_in,
-      pphost->device_prop.address,
-      pphost->device_prop.speed,
-      EP_TYPE_BULK,
-      MIDI_Machine.MIDIBulkInEpSize);
-
-  MIDI_Machine.state = MIDI_GET_DATA;
-  start_toggle =0;
-  status = USBH_OK;
-
-}
-
-else
-{
-  phost->
-  usr_cb->DeviceNotSupported();
-}
-
-return status;
-
-}
+//if((phost->device_prop.Itf_Desc[0].bInterfaceClass == USB_AUDIO_CLASS) &&
+//    (pphost->device_prop.Itf_Desc[0].bInterfaceSubClass == USB_MIDISTREAMING_SubCLASS))
+//{
+//  if(phost->device_prop.Ep_Desc[0][0].bEndpointAddress & 0x80)
+//  {
+//    MIDI_Machine.MIDIBulkInEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
+//    MIDI_Machine.MIDIBulkInEpSize = phost->device_prop.Ep_Desc[0][0].wMaxPacketSize;
+//  }
+//  else
+//  {
+//    MIDI_Machine.MIDIBulkOutEp = (phost->device_prop.Ep_Desc[0][0].bEndpointAddress);
+//    MIDI_Machine.MIDIBulkOutEpSize = phost->device_prop.Ep_Desc[0] [0].wMaxPacketSize;
+//  }
+//
+//  if(pphost->device_prop.Ep_Desc[0][1].bEndpointAddress & 0x80)
+//
+//  {
+//    MIDI_Machine.MIDIBulkInEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
+//    MIDI_Machine.MIDIBulkInEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
+//  }
+//  else
+//  {
+//    MIDI_Machine.MIDIBulkOutEp = (pphost->device_prop.Ep_Desc[0][1].bEndpointAddress);
+//    MIDI_Machine.MIDIBulkOutEpSize = pphost->device_prop.Ep_Desc[0][1].wMaxPacketSize;
+//  }
+//
+//  MIDI_Machine.hc_num_out = USBH_Alloc_Channel(pdev,
+//      MIDI_Machine.MIDIBulkOutEp);
+//  MIDI_Machine.hc_num_in = USBH_Alloc_Channel(pdev,
+//      MIDI_Machine.MIDIBulkInEp);
+//
+//  /* Open the new channels */
+//  USBH_Open_Channel (pdev,
+//      MIDI_Machine.hc_num_out,
+//      pphost->device_prop.address,
+//      pphost->device_prop.speed,
+//      EP_TYPE_BULK,
+//      MIDI_Machine.MIDIBulkOutEpSize);
+//
+//  USBH_Open_Channel (pdev,
+//      MIDI_Machine.hc_num_in,
+//      pphost->device_prop.address,
+//      pphost->device_prop.speed,
+//      EP_TYPE_BULK,
+//      MIDI_Machine.MIDIBulkInEpSize);
+//
+//  MIDI_Machine.state = MIDI_GET_DATA;
+//  start_toggle =0;
+//  status = USBH_OK;
+//
+//}
+//
+//else
+//{
+//  phost->
+//  usr_cb->DeviceNotSupported();
+//}
+//
+//return status;
+//}
 #endif
 
 /*-----------------------------------------------------------------------------------------*/
@@ -304,20 +293,20 @@ return status;
  * @param  hdev: Selected device property
  * @retval None
  */
-USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost){
+USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost) {
 #if 0
-  if (MIDI_Machine.hc_num_out) {
-    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_out);
-    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_out);
-    MIDI_Machine.hc_num_out = 0; /* Reset the Channel as Free */
-  }
-
-  if (MIDI_Machine.hc_num_in) {
-    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_in);
-    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_in);
-    MIDI_Machine.hc_num_in = 0; /* Reset the Channel as Free */
-  }
-  start_toggle = 0;
+//  if (MIDI_Machine.hc_num_out) {
+//    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_out);
+//    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_out);
+//    MIDI_Machine.hc_num_out = 0; /* Reset the Channel as Free */
+//  }
+//
+//  if (MIDI_Machine.hc_num_in) {
+//    USB_OTG_HC_Halt(pdev, MIDI_Machine.hc_num_in);
+//    USBH_Free_Channel(pdev, MIDI_Machine.hc_num_in);
+//    MIDI_Machine.hc_num_in = 0; /* Reset the Channel as Free */
+//  }
+//  start_toggle = 0;
 #else
   return USBH_OK;
 #endif
@@ -332,9 +321,9 @@ USBH_StatusTypeDef USBH_MIDI_InterfaceDeInit  (USBH_HandleTypeDef *phost){
  * @retval  USBH_Status :Response for USB Set Protocol request
  */
 static USBH_StatusTypeDef USBH_MIDI_ClassRequest(USBH_HandleTypeDef *phost) {
-  USBH_StatusTypeDef status = USBH_OK;
+    USBH_StatusTypeDef status = USBH_OK;
 
-  return status;
+    return status;
 }
 
 /*-----------------------------------------------------------------------------------------*/
@@ -352,83 +341,80 @@ volatile int state_in;
 volatile int state_out;
 
 static USBH_StatusTypeDef USBH_MIDI_Process(USBH_HandleTypeDef *phost) {
-  USBH_StatusTypeDef status = USBH_OK;
-  MIDI_HandleTypeDef *MIDI_Handle = phost->pActiveClass->pData;
-  URB_state_in = USBH_LL_GetURBState(phost, MIDI_Handle->InPipe);
-  URB_state_out = USBH_LL_GetURBState(phost, MIDI_Handle->OutPipe);
-  state_in = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
-  state_out = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
+    
+    USBH_StatusTypeDef status = USBH_OK;
+    MIDI_HandleTypeDef *MIDI_Handle = phost->pActiveClass->pData;
+    URB_state_in    = USBH_LL_GetURBState(phost, MIDI_Handle->InPipe);
+    URB_state_out   = USBH_LL_GetURBState(phost, MIDI_Handle->OutPipe);
+    state_in        = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
+    state_out       = HAL_HCD_GetState(phost->pData, MIDI_Handle->InPipe);
 
 
 //  if (HCD_IsDeviceConnected(pdev)) {
     //appliStatus = pphost->usr_cb->UserApplication(); // this will call USBH_USR_MIDI_Application()
 
-    switch (MIDI_Handle->state) {
+    switch (MIDI_Handle->state_in) {
 
     case MIDI_INIT:
-      MIDI_Handle->state = MIDI_GET_DATA;
+      MIDI_Handle->state_in = MIDI_GET_DATA;
       break;
 
     case MIDI_GET_DATA:
-      if (URB_state_in == USBH_URB_STALL){
-        USBH_ClrFeature(phost, MIDI_Handle->InEp);
-      } else       if (URB_state_in == USBH_URB_ERROR){
-        USBH_ClrFeature(phost, MIDI_Handle->InEp);
-      }
+        if (URB_state_in == USBH_URB_STALL) {
+            USBH_ClrFeature(phost, MIDI_Handle->InEp);
+        } else if (URB_state_in == USBH_URB_ERROR) {
+            USBH_ClrFeature(phost, MIDI_Handle->InEp);
+        }
 
-      USBH_BulkReceiveData(phost, MIDI_Handle->buff, USBH_MIDI_MPS_SIZE,
+        USBH_BulkReceiveData(phost, MIDI_Handle->buff, USBH_MIDI_MPS_SIZE,
                            MIDI_Handle->InPipe);
-      MIDI_Handle->state = MIDI_POLL;
-      //STM_EVAL_LEDOn(LED_Blue);
-
-      break;
+        MIDI_Handle->state_in = MIDI_POLL;
+        //STM_EVAL_LEDOn(LED_Blue);
+        break;
 
     case MIDI_POLL:
-      if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe) == USBH_URB_DONE) {
-        int i;
-        int n = USBH_LL_GetLastXferSize(phost, MIDI_Handle->InPipe);
-        for (i=0;i<n;i+=4){
-          MIDI_CB(MIDI_Handle->buff[0+i],MIDI_Handle->buff[1+i],MIDI_Handle->buff[2+i],MIDI_Handle->buff[3+i]);
-        }
-        MIDI_Handle->buff[1] = 0;
-//        MIDI_Handle->state = MIDI_IDLE;
-        MIDI_Handle->timer = 0;
-      }
-      else if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe)
-          == USBH_URB_STALL) /* IN Endpoint Stalled */
-          {
-
-        /* Issue Clear Feature on IN endpoint */
-        if (USBH_ClrFeature(phost, MIDI_Handle->InEp) == USBH_OK) {
-          /* Change state to issue next IN token */
-          MIDI_Handle->state = MIDI_GET_DATA;
-      }
-
-    }
-    break;
+        if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe) == USBH_URB_DONE) {
+            int i;
+            
+            int n = USBH_LL_GetLastXferSize(phost, MIDI_Handle->InPipe);
+            for (i=0;i<n;i+=4) {
+                MIDI_CB(MIDI_Handle->buff[0+i],MIDI_Handle->buff[1+i],MIDI_Handle->buff[2+i],MIDI_Handle->buff[3+i]);
+            }
+                
+            MIDI_Handle->buff[1] = 0;
+            //        MIDI_Handle->state_in = MIDI_IDLE;
+            MIDI_Handle->timer = 0;
+        } // if DONE
+        else if (USBH_LL_GetURBState(phost, MIDI_Handle->InPipe)== USBH_URB_STALL) {/* IN Endpoint Stalled */
+            /* Issue Clear Feature on IN endpoint */
+            if (USBH_ClrFeature(phost, MIDI_Handle->InEp) == USBH_OK) {
+              /* Change state to issue next IN token */
+              MIDI_Handle->state_in = MIDI_GET_DATA;
+            }
+        } // if STALL
+        break;
 
     default:
-    break;
-  }
-  return status;
-
+        break;
+    } // case
+    
+    return status;
 }
 /*-----------------------------------------------------------------------------------------*/
 
-static USBH_StatusTypeDef USBH_MIDI_SOFProcess(USBH_HandleTypeDef *phost){
-  MIDI_HandleTypeDef *MIDI_Handle =  (MIDI_HandleTypeDef *) phost->pActiveClass->pData;
+static USBH_StatusTypeDef USBH_MIDI_SOFProcess(USBH_HandleTypeDef *phost) {
+    MIDI_HandleTypeDef *MIDI_Handle =  (MIDI_HandleTypeDef *) phost->pActiveClass->pData;
 
-  if(MIDI_Handle->state == MIDI_POLL)
-  {
-    if(( phost->Timer - MIDI_Handle->timer) >= MIDI_Handle->poll)
-    {
-      MIDI_Handle->state = MIDI_GET_DATA;
-#if (USBH_USE_OS == 1)
-    osMessagePutI ( phost->os_event, USBH_URB_EVENT, 0);
-#endif
+    if(MIDI_Handle->state_in == MIDI_POLL) {
+        if(( phost->Timer - MIDI_Handle->timer) >= MIDI_Handle->poll)
+        {
+            MIDI_Handle->state_in = MIDI_GET_DATA;
+            #if (USBH_USE_OS == 1)
+            osMessagePutI ( phost->os_event, USBH_URB_EVENT, 0);
+            #endif
+        }
     }
-  }
-  return USBH_OK;
+    return USBH_OK;
 }
 
 /* Receive data from MIDI device *//*
@@ -451,6 +437,3 @@ else
   return 0;
 
 }*/
-/*-----------------------------------------------------------------------------------------*/
-
-/*****************************END OF FILE****/

--- a/firmware/usbh_midi_core.c
+++ b/firmware/usbh_midi_core.c
@@ -62,6 +62,10 @@ void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2)
     
 }
 
+int  usbh_MidiGetOutputBufferPending()
+{
+    return 0;
+}
 
 /** @defgroup USBH_MIDI_CORE_Private_Variables
  * @{

--- a/firmware/usbh_midi_core.h
+++ b/firmware/usbh_midi_core.h
@@ -40,7 +40,7 @@ void usbh_midi_init(void);
 void usbh_MidiSend1(uint8_t port, uint8_t b0);
 void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1);
 void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
-int  usbh_MidiGetOutputBufferPending();
+int  usbh_MidiGetOutputBufferPending(void);
 
 //#define MIDI_MIN_POLL          10
 #define USBH_MIDI_MPS_SIZE  64
@@ -107,13 +107,16 @@ typedef struct _MIDI_Process {
   uint16_t InEpSize;
   MIDI_State_t state_in;
   MIDI_State_t state_out;
+  bool input_valid;
+  bool output_valid;
 
-  uint8_t buff[USBH_MIDI_MPS_SIZE];
+  uint8_t buff_in[USBH_MIDI_MPS_SIZE];
+  uint8_t buff_out[USBH_MIDI_MPS_SIZE];
 //  uint16_t             length;
-  uint8_t              ep_addr;
+//  uint8_t              ep_addr;
   uint16_t             poll;
   uint16_t             timer;
-  uint8_t              DataReady;
+//  uint8_t              DataReady;
 //  USBH_MIDIDesc_t      HID_Desc;
   USBH_StatusTypeDef  ( * Init)(USBH_HandleTypeDef *phost);
 } MIDI_HandleTypeDef;
@@ -126,7 +129,7 @@ extern USBH_Class_cb_TypeDef MIDI_cb;
 
 extern void MIDI_CB(uint8_t a,uint8_t b,uint8_t c,uint8_t d);
 
-uint8_t MIDI_RcvData(uint8_t *outBuf);
+//uint8_t MIDI_RcvData(uint8_t *outBuf);
 
 typedef USBH_HandleTypeDef USB_OTG_CORE_HANDLE;
 

--- a/firmware/usbh_midi_core.h
+++ b/firmware/usbh_midi_core.h
@@ -105,7 +105,8 @@ typedef struct _MIDI_Process {
   uint8_t InEp;
   uint16_t OutEpSize;
   uint16_t InEpSize;
-  MIDI_State_t state;
+  MIDI_State_t state_in;
+  MIDI_State_t state_out;
 
   uint8_t buff[USBH_MIDI_MPS_SIZE];
 //  uint16_t             length;

--- a/firmware/usbh_midi_core.h
+++ b/firmware/usbh_midi_core.h
@@ -34,6 +34,15 @@
 //#include "usbh_usr.h"
 //#include "midi_interface.h"
 
+
+// external midi interface
+void usbh_midi_init(void);
+void usbh_MidiSend1(uint8_t port, uint8_t b0);
+void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1);
+void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
+
+
+
 //#define MIDI_MIN_POLL          10
 #define USBH_MIDI_MPS_SIZE  64
 #define USB_AUDIO_CLASS 0x01

--- a/firmware/usbh_midi_core.h
+++ b/firmware/usbh_midi_core.h
@@ -40,8 +40,7 @@ void usbh_midi_init(void);
 void usbh_MidiSend1(uint8_t port, uint8_t b0);
 void usbh_MidiSend2(uint8_t port, uint8_t b0, uint8_t b1);
 void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
-
-
+int  usbh_MidiGetOutputBufferPending();
 
 //#define MIDI_MIN_POLL          10
 #define USBH_MIDI_MPS_SIZE  64

--- a/firmware/usbh_midi_core.h
+++ b/firmware/usbh_midi_core.h
@@ -43,7 +43,8 @@ void usbh_MidiSend3(uint8_t port, uint8_t b0, uint8_t b1, uint8_t b2);
 int  usbh_MidiGetOutputBufferPending(void);
 
 //#define MIDI_MIN_POLL          10
-#define USBH_MIDI_MPS_SIZE  64
+#define USBH_MIDI_EPS_IN_SIZE  32
+#define USBH_MIDI_EPS_OUT_SIZE 32
 #define USB_AUDIO_CLASS 0x01
 #define USB_MIDISTREAMING_SubCLASS 0x03
 
@@ -110,8 +111,8 @@ typedef struct _MIDI_Process {
   bool input_valid;
   bool output_valid;
 
-  uint8_t buff_in[USBH_MIDI_MPS_SIZE];
-  uint8_t buff_out[USBH_MIDI_MPS_SIZE];
+  uint8_t buff_in[USBH_MIDI_EPS_IN_SIZE];
+  uint8_t buff_out[USBH_MIDI_EPS_OUT_SIZE];
 //  uint16_t             length;
 //  uint8_t              ep_addr;
   uint16_t             poll;

--- a/objects/midi/intern/bend.axo
+++ b/objects/midi/intern/bend.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="bend" sha="dd9c5285086369846d3afbff18b34630ce90755d">
+   <obj.normal id="bend" sha="4e335b77f4cfe3388be602d79f87664638917cab">
       <sDescription>Midi pitch bend output. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -15,7 +15,7 @@
       </attribs>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler(MIDI_PITCH_BEND + (%channel%-1),(%bend%>>14)&0x7F,(%bend%>>21)+64);  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler((midi_device_t) 0,0,MIDI_PITCH_BEND + (%channel%-1),(%bend%>>14)&0x7F,(%bend%>>21)+64);  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/intern/cc any.axo
+++ b/objects/midi/intern/cc any.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc any" sha="dec68a24c8e41f16766599e71618e83ea4e6f829">
+   <obj.normal id="cc any" sha="cbd852fde94a109b7678f37a8ec8056624848649">
       <sDescription>Midi controller output to any CC number and channel. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -15,7 +15,7 @@
       <attribs/>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler(MIDI_CONTROL_CHANGE + ((%chan%-1)&0xF),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler((midi_device_t) 0,0,MIDI_CONTROL_CHANGE + ((%chan%-1)&0xF),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/intern/cc thin.axo
+++ b/objects/midi/intern/cc thin.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc thin" sha="970061517641cff6d9187b1ee39abd939aaf8f1d">
+   <obj.normal id="cc thin" sha="9ae399656e566286d8a0310d63d27427ee5eb528">
       <sDescription>Midi controller output, automatic thinning. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -20,7 +20,7 @@ int timer;
 ]]></code.init>
       <code.krate><![CDATA[if (((lsend>%v%+(1<<19))||(%v%>lsend+(1<<19))) && (timer>30)) {
    lsend = %v%;
-   PatchMidiInHandler(MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));
+   PatchMidiInHandler((midi_device_t) 0,0,MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));
    timer = 0;
 } else timer++;
 ]]></code.krate>

--- a/objects/midi/intern/cc.axo
+++ b/objects/midi/intern/cc.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc" sha="bd6fd5939aec7e7b2fe0731f51947229495cecc">
+   <obj.normal id="cc" sha="f8dcc1f2fcd6be51fdd40b86f3e71fe6563caa77">
       <sDescription>Midi controller output. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -16,7 +16,7 @@
       </attribs>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler(MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {PatchMidiInHandler((midi_device_t) 0,0,MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/intern/clock.axo
+++ b/objects/midi/intern/clock.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="clock" sha="e512b6c35edd6129c934e3225fb8c9de2cf80dee">
+   <obj.normal id="clock" sha="4fcd0a4f964ff207b24f342599cac6607d302ce">
       <sDescription>Midi clock master, als outputs Midi clock, start, stop, and continue messages. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -38,17 +38,17 @@ rstp = 0;]]></code.init>
 }
 if (%run% && !_active) {
   _active = 1;
-  if (_pos24ppq)     PatchMidiInHandler(MIDI_START,0,0);
-  else     PatchMidiInHandler(MIDI_CONTINUE,0,0);
+  if (_pos24ppq)     PatchMidiInHandler((midi_device_t) 0,0,MIDI_START,0,0);
+  else     PatchMidiInHandler((midi_device_t) 0,0,MIDI_CONTINUE,0,0);
 } else if (!%run% && _active){
   _active = 0;
-  PatchMidiInHandler(MIDI_STOP,0,0);
+  PatchMidiInHandler((midi_device_t) 0,0,MIDI_STOP,0,0);
 }if (_active) {
   _posfrac += %bpm%;
   if (_posfrac & 1<<31) {
     _posfrac &= (1<<31)-1;
     _pos24ppq++;
-    PatchMidiInHandler(MIDI_TIMING_CLOCK,0,0);
+    PatchMidiInHandler((midi_device_t) 0,0,MIDI_TIMING_CLOCK,0,0);
   }
 }
 %pos4ppq% = _pos24ppq/6;

--- a/objects/midi/intern/note.axo
+++ b/objects/midi/intern/note.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="note" sha="601f57c317af33226524f5c49537789f8d7967eb">
+   <obj.normal id="note" sha="1ff49c3a266ffddbf62484c4e3d282b7197b771">
       <sDescription>Midi note output. Sends to midi/in/* objects only.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -20,9 +20,9 @@ int lastnote;]]></code.declaration>
 ]]></code.init>
       <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {
 lastnote = (64+(%note%>>21))&0x7F;
-PatchMidiInHandler(MIDI_NOTE_ON + (%channel%-1),lastnote,%velo%>>20);  ntrig=1;
+PatchMidiInHandler((midi_device_t) 0,0,MIDI_NOTE_ON + (%channel%-1),lastnote,%velo%>>20);  ntrig=1;
 }
-if (!(%trig%>0) && ntrig) {PatchMidiInHandler(MIDI_NOTE_OFF + (%channel%-1),lastnote,__USAT(%velo%>>20,7)); ntrig=0;}
+if (!(%trig%>0) && ntrig) {PatchMidiInHandler((midi_device_t) 0,0,MIDI_NOTE_OFF + (%channel%-1),lastnote,__USAT(%velo%>>20,7)); ntrig=0;}
 ]]></code.krate>
    </obj.normal>
 </objdefs>

--- a/objects/midi/out/bend.axo
+++ b/objects/midi/out/bend.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="bend" sha="558e140dfe5cb9a7519e288da16e9a3430e6143a">
+   <obj.normal id="bend" sha="c606ddb38c482fa16c4243c0bf86fee0f618328f">
       <sDescription>Midi pitch bend output</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -11,11 +11,13 @@
       <displays/>
       <params/>
       <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3(MIDI_PITCH_BEND + (%channel%-1),(%bend%>>14)&0x7F,(%bend%>>21)+64);  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3((midi_device_t) %device%,%port%,MIDI_PITCH_BEND + (%channel%-1),(%bend%>>14)&0x7F,(%bend%>>21)+64);  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/out/bend.axo
+++ b/objects/midi/out/bend.axo
@@ -11,7 +11,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>

--- a/objects/midi/out/cc any.axo
+++ b/objects/midi/out/cc any.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc any" sha="86d48b2affb47053582469232764da4f1d11fb38">
+   <obj.normal id="cc any" sha="e7eda788b80acbd0a96640964c1cfaf484d5520b">
       <sDescription>Midi controller output to any CC number and channel</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -12,10 +12,13 @@
       <outlets/>
       <displays/>
       <params/>
-      <attribs/>
+      <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
+      </attribs>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3(MIDI_CONTROL_CHANGE + ((%chan%-1)&0xF),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3((midi_device_t) %device%,%port%,MIDI_CONTROL_CHANGE + ((%chan%-1)&0xF),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/out/cc any.axo
+++ b/objects/midi/out/cc any.axo
@@ -13,7 +13,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>
       <code.declaration><![CDATA[int ntrig;

--- a/objects/midi/out/cc thin.axo
+++ b/objects/midi/out/cc thin.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc thin" sha="340f1ee753ac70acbbe52970a81cc8549063b29a">
+   <obj.normal id="cc thin" sha="dab6968b122b82e459e1dbfb068869f13ff1bb91">
       <sDescription>Midi controller output, automatic thinning</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -10,6 +10,8 @@
       <displays/>
       <params/>
       <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="cc" MinValue="0" MaxValue="127" DefaultValue="0"/>
       </attribs>
@@ -20,7 +22,7 @@ int timer;
 ]]></code.init>
       <code.krate><![CDATA[if (((lsend>%v%+(1<<19))||(%v%>lsend+(1<<19))) && (timer>30)) {
    lsend = %v%;
-   MidiSend3(MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));
+   MidiSend3((midi_device_t) %device%,%port%,MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));
    timer = 0;
 } else timer++;
 ]]></code.krate>

--- a/objects/midi/out/cc thin.axo
+++ b/objects/midi/out/cc thin.axo
@@ -10,7 +10,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="cc" MinValue="0" MaxValue="127" DefaultValue="0"/>

--- a/objects/midi/out/cc.axo
+++ b/objects/midi/out/cc.axo
@@ -11,7 +11,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="cc" MinValue="0" MaxValue="127" DefaultValue="0"/>

--- a/objects/midi/out/cc.axo
+++ b/objects/midi/out/cc.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="cc" sha="b75c29c4a673c3cf1b0c417741358ea446de1b85">
+   <obj.normal id="cc" sha="cb1d3d7811107ef088eeaacc950cfeb25aeec445">
       <sDescription>Midi controller output</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -11,12 +11,14 @@
       <displays/>
       <params/>
       <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="cc" MinValue="0" MaxValue="127" DefaultValue="0"/>
       </attribs>
       <code.declaration><![CDATA[int ntrig;
 ]]></code.declaration>
-      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3(MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
+      <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {MidiSend3((midi_device_t) %device%,%port%,MIDI_CONTROL_CHANGE + (%channel%-1),%cc%,__USAT(%v%>>20,7));  ntrig=1;}
 if (!(%trig%>0)) ntrig=0;
 ]]></code.krate>
    </obj.normal>

--- a/objects/midi/out/clock.axo
+++ b/objects/midi/out/clock.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="clock" sha="b9dcbd2415a27e4361d5567f4aacd3c7c0aa64a7">
+   <obj.normal id="clock" sha="5f08a38532f31c69e08955bff1356f2105a478b6">
       <sDescription>Midi clock master, als outputs Midi clock, start, stop, and continue messages</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -19,7 +19,10 @@
             <MaxValue v="63.5"/>
          </frac32.u.map>
       </params>
-      <attribs/>
+      <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
+      </attribs>
       <code.declaration><![CDATA[bool _active;
 int32_t _posfrac;
 int32_t _pos24ppq;
@@ -38,17 +41,17 @@ rstp = 0;]]></code.init>
 }
 if (%run% && !_active) {
   _active = 1;
-  if (_pos24ppq)     MidiSend1(MIDI_START);
-  else     MidiSend1(MIDI_CONTINUE);
+  if (_pos24ppq)     MidiSend1((midi_device_t) %device%,%port%,MIDI_START);
+  else     MidiSend1((midi_device_t) %device%,%port%,MIDI_CONTINUE);
 } else if (!%run% && _active){
   _active = 0;
-  MidiSend1(MIDI_STOP);
+  MidiSend1((midi_device_t) %device%,%port%,MIDI_STOP);
 }if (_active) {
   _posfrac += %bpm%;
   if (_posfrac & 1<<31) {
     _posfrac &= (1<<31)-1;
     _pos24ppq++;
-    MidiSend1(MIDI_TIMING_CLOCK);
+    MidiSend1((midi_device_t) %device%,%port%,MIDI_TIMING_CLOCK);
   }
 }
 %pos4ppq% = _pos24ppq/6;

--- a/objects/midi/out/clock.axo
+++ b/objects/midi/out/clock.axo
@@ -20,7 +20,18 @@
          </frac32.u.map>
       </params>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>
       <code.declaration><![CDATA[bool _active;

--- a/objects/midi/out/note.axo
+++ b/objects/midi/out/note.axo
@@ -12,7 +12,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
          <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>

--- a/objects/midi/out/note.axo
+++ b/objects/midi/out/note.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="note" sha="8572cb79992ae63248030b5e1d69f0460dc77e5b">
+   <obj.normal id="note" sha="588b931eb52cdd8bc574354c97d9f9e5d1b5ef4a">
       <sDescription>Midi note output</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -12,6 +12,8 @@
       <displays/>
       <params/>
       <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <spinner name="port" MinValue="1" MaxValue="16" DefaultValue="0"/>
          <spinner name="channel" MinValue="1" MaxValue="16" DefaultValue="0"/>
       </attribs>
       <code.declaration><![CDATA[int ntrig;
@@ -20,9 +22,9 @@ int lastnote;]]></code.declaration>
 ]]></code.init>
       <code.krate><![CDATA[if ((%trig%>0) && !ntrig) {
 lastnote = (64+(%note%>>21))&0x7F;
-MidiSend3(MIDI_NOTE_ON + (%channel%-1),lastnote,%velo%>>20);  ntrig=1;
+MidiSend3((midi_device_t) %device%,%port%,MIDI_NOTE_ON + (%channel%-1),lastnote,%velo%>>20);  ntrig=1;
 }
-if (!(%trig%>0) && ntrig) {MidiSend3(MIDI_NOTE_OFF + (%channel%-1),lastnote,__USAT(%velo%>>20,7)); ntrig=0;}
+if (!(%trig%>0) && ntrig) {MidiSend3((midi_device_t) %device%,%port%,MIDI_NOTE_OFF + (%channel%-1),lastnote,__USAT(%velo%>>20,7)); ntrig=0;}
 ]]></code.krate>
    </obj.normal>
 </objdefs>

--- a/objects/midi/out/queuestate.axo
+++ b/objects/midi/out/queuestate.axo
@@ -10,7 +10,18 @@
       <displays/>
       <params/>
       <attribs>
-         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+         <combo name="device">
+            <MenuEntries>
+               <string>serial</string>
+               <string>usb device</string>
+               <string>usb host</string>
+            </MenuEntries>
+            <CEntries>
+               <string>1</string>
+               <string>2</string>
+               <string>3</string>
+            </CEntries>
+         </combo>
       </attribs>
       <code.krate><![CDATA[%length% = MidiGetOutputBufferPending((midi_device_t) %device%);
 ]]></code.krate>

--- a/objects/midi/out/queuestate.axo
+++ b/objects/midi/out/queuestate.axo
@@ -1,5 +1,5 @@
 <objdefs>
-   <obj.normal id="queuestate" sha="bffa8d458597bd2fea30e8e4360f47b3c153fc88">
+   <obj.normal id="queuestate" sha="285ac1c9764f8f7b721aa750f5bd63f63e2578d5">
       <sDescription>Gets the number of pending bytes in the midi output queue. Useful to prevent midi data flooding. Zero at rest.</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -9,8 +9,10 @@
       </outlets>
       <displays/>
       <params/>
-      <attribs/>
-      <code.krate><![CDATA[%length% = MidiGetOutputBufferPending();
+      <attribs>
+         <spinner name="device" MinValue="1" MaxValue="5" DefaultValue="0"/>
+      </attribs>
+      <code.krate><![CDATA[%length% = MidiGetOutputBufferPending((midi_device_t) %device%);
 ]]></code.krate>
    </obj.normal>
 </objdefs>

--- a/src/main/java/axoloti/AxolotiMidiInput.java
+++ b/src/main/java/axoloti/AxolotiMidiInput.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2013, 2014, 2015 Johannes Taelman
+ *
+ * This file is part of Axoloti.
+ *
+ * Axoloti is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Axoloti is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Axoloti. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package axoloti;
+
+import axoloti.dialogs.KeyboardFrame;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiMessage;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.Receiver;
+import javax.swing.SpinnerNumberModel;
+import jssc.SerialPortException;
+
+
+public class AxolotiMidiInput implements Receiver {
+    public AxolotiMidiInput() {
+        device=null;
+    }
+    
+    public void start(String midiDevice) {
+        close();
+        
+        if(midiDevice.isEmpty()) return;
+        
+        MidiDevice.Info[] devices;
+        devices = MidiSystem.getMidiDeviceInfo();
+
+        for (MidiDevice.Info info: devices) {
+            try {
+                if(info.getName().equals(midiDevice))
+                {
+                    MidiDevice dev = MidiSystem.getMidiDevice(info);
+                    dev.open();
+                    if(dev.isOpen()) {
+                        dev.getTransmitter().setReceiver(this);
+                    }
+                }
+            }
+            catch (MidiUnavailableException e)
+            {
+            }
+        }
+    }
+    public void send(MidiMessage msg,long timesStamp) {
+        SerialConnection connection = MainFrame.mainframe.getQcmdprocessor().serialconnection;
+        if ((connection != null) && connection.isConnected()) {
+            try {
+                byte[] b = msg.getMessage();
+                byte b0 = b[0];
+                byte b1 = (msg.getLength()>1 ? b[1] : 0); 
+                byte b2 = (msg.getLength()>2 ? b[2] : 0); 
+                if (b0 != (byte)254) { 
+                    connection.SendMidi(b0,b1,b2);
+                }
+            } catch (SerialPortException ex) {
+                Logger.getLogger(AxolotiMidiInput.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+    }
+    
+    public void close() {
+        if (device!=null) {
+            device.close();
+        }
+    }
+    private MidiDevice device;
+}

--- a/src/main/java/axoloti/MainFrame.java
+++ b/src/main/java/axoloti/MainFrame.java
@@ -82,6 +82,7 @@ public class MainFrame extends javax.swing.JFrame implements ActionListener {
     QCmdProcessor qcmdprocessor;
     Thread qcmdprocessorThread;
     static public Cursor transparentCursor;
+    AxolotiMidiInput midiInput;
 
     /**
      * Creates new form MainFrame
@@ -177,6 +178,8 @@ public class MainFrame extends javax.swing.JFrame implements ActionListener {
 
         axoObjects = new AxoObjects();
         axoObjects.LoadAxoObjects();
+        midiInput = new AxolotiMidiInput();
+        initMidiInput(prefs.getMidiInputDevice());
     }
 
     void PopulateExamplesMenu(JMenu parent) {
@@ -903,4 +906,7 @@ jMenuSelectCom.addActionListener(new java.awt.event.ActionListener() {
         }
     }
 
+    public void initMidiInput(String midiInputDevice) {
+        midiInput.start(midiInputDevice);
+    }
 }

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -1492,7 +1492,7 @@ public class Patch {
                 + "      voicePriority[i] = priority++;\n"
                 + "      pressed[i] = 0;\n"
                 + "      if (!sustain)\n"
-                + "        getVoices()[i].MidiInHandler(status, data1, data2);\n"
+                + "        getVoices()[i].MidiInHandler(dev, port, status, data1, data2);\n"
                 + "      }\n"
                 + "  }\n"
                 + "} else if (status == %midichannel% + MIDI_CONTROL_CHANGE) {\n"

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -1468,8 +1468,8 @@ public class Patch {
          */
 
         ao.sMidiCode = ""
-                + "if ( %mididevice% > 0 && %mididevice% != dev) return; \n"
-                + "if ( %midiport% > 0 && %midiport% != port) return; \n"
+                + "if ( %mididevice% > 0 && dev > 0 && %mididevice% != dev) return;\n"
+                + "if ( %midiport% > 0 && port > 0 && %midiport% != port) return;\n"
                 + "if ((status == MIDI_NOTE_ON + %midichannel%) && (data2)) {\n"
                 + "  int min = 1<<30;\n"
                 + "  int mini = 0;\n"
@@ -1528,8 +1528,8 @@ public class Patch {
                 +  "   voiceChannel[vc]=0xFF;\n"
                 +  "}\n";
         o.sMidiCode = ""
-                + "if ( %mididevice% > 0 && %mididevice% != dev) return; \n"
-                + "if ( %midiport% > 0 && %midiport% != port) return; \n"
+                + "if ( %mididevice% > 0 && dev > 0 && %mididevice% != dev) return;\n"
+                + "if ( %midiport% > 0 && port > 0 && %midiport% != port) return;\n"
                 + "int msg = (status & 0xF0);\n"
                 + "int channel = (status & 0x0F);\n"
                 + "if ((msg == MIDI_NOTE_ON) && (data2)) {\n"
@@ -1614,13 +1614,13 @@ public class Patch {
                 +  "   voiceChannel[vc]=0xFF;\n"
                 +  "}\n"
                 +  "lowChannel = %midichannel% + 1;\n"
-                +  "highChannel = %midichannel% + ( 15 - %midichannel%) ;\n"
+                +  "highChannel = %midichannel% + ( 15 - %midichannel%);\n"
                 +  "pitchbendRange = 48;\n"
                 +  "lastRPN_LSB=0xFF;\n"
                 +  "lastRPN_MSB=0xFF;\n";
         o.sMidiCode = ""
-                + "if ( %mididevice% > 0 && %mididevice% != dev) return; \n"
-                + "if ( %midiport% > 0 && %midiport% != port) return; \n"
+                + "if ( %mididevice% > 0 && dev > 0 && %mididevice% != dev) return;\n"
+                + "if ( %midiport% > 0 && port > 0 && %midiport% != port) return;\n"
                 + "int msg = (status & 0xF0);\n"
                 + "int channel = (status & 0x0F);\n"
                 + "if ((msg == MIDI_NOTE_ON) && (data2)) {\n"

--- a/src/main/java/axoloti/dialogs/PreferencesFrame.form
+++ b/src/main/java/axoloti/dialogs/PreferencesFrame.form
@@ -26,7 +26,14 @@
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jScrollPane1" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="-2" pref="51" max="-2" attributes="0"/>
+                      <Component id="jScrollPane1" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="1" attributes="0">
+                      <EmptySpace min="-2" pref="226" max="-2" attributes="0"/>
+                      <Component id="jButtonSave" max="32767" attributes="0"/>
+                  </Group>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -42,11 +49,12 @@
                               </Group>
                           </Group>
                       </Group>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="20" max="32767" attributes="0"/>
                   </Group>
-                  <Group type="102" alignment="1" attributes="0">
-                      <EmptySpace min="-2" pref="226" max="-2" attributes="0"/>
-                      <Component id="jButtonSave" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="53" max="-2" attributes="0"/>
+                      <Component id="jComboBox2" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -60,7 +68,12 @@
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jScrollPane1" min="-2" pref="64" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel4" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jComboBox2" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jTextFieldPollInterval" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -131,6 +144,21 @@
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jComboBox1ActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel4">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Midi Input"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="jComboBox2">
+      <Properties>
+        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+          <StringArray count="0"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jComboBox2ActionPerformed"/>
       </Events>
     </Component>
   </SubComponents>

--- a/src/main/java/axoloti/dialogs/PreferencesFrame.java
+++ b/src/main/java/axoloti/dialogs/PreferencesFrame.java
@@ -18,6 +18,9 @@
 package axoloti.dialogs;
 
 import axoloti.utils.Preferences;
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
 
 /**
  *
@@ -25,6 +28,7 @@ import axoloti.utils.Preferences;
  */
 public class PreferencesFrame extends javax.swing.JFrame {
 
+    final static String  MidiNone = "None";
     Preferences prefs;
 
     /**
@@ -43,12 +47,38 @@ public class PreferencesFrame extends javax.swing.JFrame {
             p += s + "\n";
         }
         jTextPanePath.setText(p);
+                
+        MidiDevice.Info[] devices;
+        devices = MidiSystem.getMidiDeviceInfo();
+
+        jComboBox2.addItem(MidiNone);
+        for (MidiDevice.Info info: devices) {
+            try {
+                MidiDevice dev = MidiSystem.getMidiDevice(info);
+                // yuch, only way to determine input devices, is by seeing
+                // if they are com.sun.media.sound.MidiInDevice, but this is a
+                // private class 
+                if (dev.getClass().getName().toLowerCase().contains("midiindevice")) {
+                    jComboBox2.addItem(info.getName());
+                }
+            }
+            catch (MidiUnavailableException e)
+            {
+            }               
+        }
+        String md=prefs.getMidiInputDevice();
+        if(!md.isEmpty()) {
+            jComboBox2.setSelectedItem(md);
+        }
     }
 
     void Apply() {
         prefs.setPollInterval(Integer.parseInt(jTextFieldPollInterval.getText()));
         prefs.setObjectSearchPath(jTextPanePath.getText().split("\n"));
         prefs.setMouseDialAngular(jComboBox1.getSelectedItem().equals("Angular"));
+        String dev = (String) jComboBox2.getSelectedItem();
+        if(dev.equals(MidiNone)) dev="";
+        prefs.setMidiInputDevice((String) dev);
     }
 
     /**
@@ -68,6 +98,8 @@ public class PreferencesFrame extends javax.swing.JFrame {
         jButtonSave = new javax.swing.JButton();
         jLabel3 = new javax.swing.JLabel();
         jComboBox1 = new javax.swing.JComboBox();
+        jLabel4 = new javax.swing.JLabel();
+        jComboBox2 = new javax.swing.JComboBox();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
 
@@ -96,6 +128,14 @@ public class PreferencesFrame extends javax.swing.JFrame {
             }
         });
 
+        jLabel4.setText("Midi Input");
+
+        jComboBox2.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jComboBox2ActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
@@ -103,7 +143,12 @@ public class PreferencesFrame extends javax.swing.JFrame {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jScrollPane1)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(51, 51, 51)
+                        .addComponent(jScrollPane1))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                        .addGap(226, 226, 226)
+                        .addComponent(jButtonSave, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(jLabel1)
@@ -115,10 +160,11 @@ public class PreferencesFrame extends javax.swing.JFrame {
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                                     .addComponent(jTextFieldPollInterval, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, 74, javax.swing.GroupLayout.PREFERRED_SIZE)
                                     .addComponent(jComboBox1, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                        .addGap(0, 0, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                        .addGap(226, 226, 226)
-                        .addComponent(jButtonSave, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                        .addGap(0, 20, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(jLabel4)
+                        .addGap(53, 53, 53)
+                        .addComponent(jComboBox2, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -128,7 +174,11 @@ public class PreferencesFrame extends javax.swing.JFrame {
                 .addComponent(jLabel1)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 64, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGap(4, 4, 4)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel4)
+                    .addComponent(jComboBox2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel2)
                     .addComponent(jTextFieldPollInterval, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -153,12 +203,17 @@ public class PreferencesFrame extends javax.swing.JFrame {
     private void jComboBox1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBox1ActionPerformed
     }//GEN-LAST:event_jComboBox1ActionPerformed
 
+    private void jComboBox2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBox2ActionPerformed
+    }//GEN-LAST:event_jComboBox2ActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jButtonSave;
     private javax.swing.JComboBox jComboBox1;
+    private javax.swing.JComboBox jComboBox2;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel3;
+    private javax.swing.JLabel jLabel4;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTextField jTextFieldPollInterval;
     private javax.swing.JTextPane jTextPanePath;

--- a/src/main/java/axoloti/object/AxoObjectInstance.java
+++ b/src/main/java/axoloti/object/AxoObjectInstance.java
@@ -630,7 +630,7 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract {
         {
             String d3 = GenerateCodeMidiHandler("");
             if (!d3.isEmpty()) {
-                s += "void MidiInHandler(uint8_t status, uint8_t data1, uint8_t data2){\n";
+                s += "void MidiInHandler(midi_device_t dev, uint8_t port, uint8_t status, uint8_t data1, uint8_t data2){\n";
                 s += d3;
                 s += "}\n";
             }
@@ -664,11 +664,11 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract {
     @Override
     public String GenerateCallMidiHandler() {
         if ((getType().sMidiCode != null) && (!getType().sMidiCode.isEmpty())) {
-            return getCInstanceName() + "_i.MidiInHandler(status, data1, data2);\n";
+            return getCInstanceName() + "_i.MidiInHandler(dev, port, status, data1, data2);\n";
         }
         for (ParameterInstance pi : getParameterInstances()) {
             if (!pi.GenerateCodeMidiHandler("").isEmpty()) {
-                return getCInstanceName() + "_i.MidiInHandler(status, data1, data2);\n";
+                return getCInstanceName() + "_i.MidiInHandler(dev, port, status, data1, data2);\n";
             }
         }
         return "";

--- a/src/main/java/axoloti/utils/Preferences.java
+++ b/src/main/java/axoloti/utils/Preferences.java
@@ -17,6 +17,7 @@
  */
 package axoloti.utils;
 
+import axoloti.MainFrame;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.logging.Level;
@@ -48,6 +49,8 @@ public class Preferences {
     Boolean ExpertMode;
     @ElementList(required = false)
     ArrayList<String> recentFiles = new ArrayList<String>();
+    @Element(required = false)
+    String MidiInputDevice;
 
     boolean isDirty = false;
 
@@ -73,6 +76,9 @@ public class Preferences {
         }
         if (ExpertMode == null) {
             ExpertMode = false;
+        }
+        if (MidiInputDevice == null) {
+            MidiInputDevice = "";
         }
     }
 
@@ -185,6 +191,7 @@ public class Preferences {
     public ArrayList<String> getRecentFiles() {
         return recentFiles;
     }
+   
 
     public void addRecentFile(String filename) {
         for (String r : recentFiles) {
@@ -199,4 +206,16 @@ public class Preferences {
         SetDirty();
     }
 
+    public String getMidiInputDevice() {
+        return MidiInputDevice;
+    }
+
+    public void setMidiInputDevice(String MidiInputDevice) {
+        if(this.MidiInputDevice.equals(MidiInputDevice)) {
+            return;
+        }
+        this.MidiInputDevice = MidiInputDevice;
+        MainFrame.mainframe.initMidiInput(this.MidiInputDevice);
+        SetDirty();
+    }
 }

--- a/src/main/java/generatedobjects/Midi.java
+++ b/src/main/java/generatedobjects/Midi.java
@@ -19,6 +19,7 @@ package generatedobjects;
 
 import axoloti.attributedefinition.AxoAttributeSpinner;
 import axoloti.attributedefinition.AxoAttributeTextEditor;
+import axoloti.attributedefinition.AxoAttributeComboBox;
 import axoloti.inlets.InletBool32;
 import axoloti.inlets.InletBool32Rising;
 import axoloti.inlets.InletFrac32Bipolar;
@@ -631,7 +632,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_clockgen() {
         AxoObject o = new AxoObject("clock", "Midi clock master, als outputs Midi clock, start, stop, and continue messages");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));        
         o.inlets.add(new InletBool32("run", "Run"));
         o.inlets.add(new InletBool32Rising("rst", "Reset"));
@@ -680,7 +685,12 @@ public class Midi extends gentools {
 
     static AxoObject Create_noteout() {
         AxoObject o = new AxoObject("note", "Midi note output");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));        
         o.attributes.add(new AxoAttributeSpinner("channel", 1, 16, 0));
         o.inlets.add(new InletFrac32Bipolar("note", "note (-64..63)"));
@@ -689,7 +699,8 @@ public class Midi extends gentools {
         o.sLocalData = "int ntrig;\n"
                 + "int lastnote;";
         o.sInitCode = "ntrig=0;\n";
-        o.sKRateCode = "if ((%trig%>0) && !ntrig) {\n"
+        o.sKRateCode = "" 
+                + "if ((%trig%>0) && !ntrig) {\n"
                 + "lastnote = (64+(%note%>>21))&0x7F;\n"
                 + "MidiSend3((midi_device_t) %device%,%port%,MIDI_NOTE_ON + (%channel%-1),lastnote,%velo%>>20);  ntrig=1;\n"
                 + "}\n"
@@ -699,7 +710,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_ctlout() {
         AxoObject o = new AxoObject("cc", "Midi controller output");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));        
         o.attributes.add(new AxoAttributeSpinner("channel", 1, 16, 0));
         o.attributes.add(new AxoAttributeSpinner("cc", 0, 127, 0));
@@ -714,7 +729,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_ctlout_any() {
         AxoObject o = new AxoObject("cc any", "Midi controller output to any CC number and channel");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));        
         o.inlets.add(new InletFrac32Pos("v", "value"));
         o.inlets.add(new InletInt32Pos("cc", "midi Continous Controller number 0-127"));
@@ -728,7 +747,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_ctloutauto() {
         AxoObject o = new AxoObject("cc thin", "Midi controller output, automatic thinning");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));
         o.attributes.add(new AxoAttributeSpinner("channel", 1, 16, 0));
         o.attributes.add(new AxoAttributeSpinner("cc", 0, 127, 0));
@@ -747,7 +770,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_bendout() {
         AxoObject o = new AxoObject("bend", "Midi pitch bend output");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.attributes.add(new AxoAttributeSpinner("port", 1, 16, 0));
         o.attributes.add(new AxoAttributeSpinner("channel", 1, 16, 0));
         o.inlets.add(new InletFrac32Bipolar("bend", "pitch bend"));
@@ -773,7 +800,11 @@ public class Midi extends gentools {
 
     static AxoObject Create_queuestate() {
         AxoObject o = new AxoObject("queuestate", "Gets the number of pending bytes in the midi output queue. Useful to prevent midi data flooding. Zero at rest.");
-        o.attributes.add(new AxoAttributeSpinner("device", 1, 5, 0));        
+        String cdev[] = {"1", "2", "3"};
+        String udev[] = {"serial", "usb device", "usb host"};
+//        String cdev[] = {"1", "2", "3", "4", "5"};
+//        String udev[] = {"serial", "usb device", "usb host", "digital x1", "digital x2"};
+        o.attributes.add(new AxoAttributeComboBox("device", udev, cdev));
         o.outlets.add(new OutletInt32("length", "number of pending bytes in queue"));
 
         o.sKRateCode = "%length% = MidiGetOutputBufferPending((midi_device_t) %device%);\n";


### PR DESCRIPTION
ok, tested all the changes, and all seems to work well. (midi device/port changes)

basically:
- midiinhandler is now passed device and port
- when you create a sub patcher instance, you are able to specific device/port (or omni for all messages), the default is OMNI
- all midi output objects now have selectors for device and port, and default to serial (=MIDI DIN) 

so behaviour is the same as before, you will get all messages for all interfaces, and output defaults to serial(=din)  (which is the only one implemented :))

