### PR TITLE
use relative path when loading a patch, use name and relative path wh…

### DIFF
--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -86,9 +86,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         if (type.createdFromRelativePath && (patch1 != null)) {
             String pPath = patch1.getFileNamePath();
             String oPath = type.sPath;
-            if (pPath.endsWith(".axp") || pPath.endsWith(".axo")) {
-                pPath = pPath.substring(0, pPath.length() - 4);
-            }
+
             if (oPath.endsWith(".axp") || oPath.endsWith(".axo")) {
                 oPath = oPath.substring(0, oPath.length() - 4);
             }

--- a/src/main/java/axoloti/object/AxoObjects.java
+++ b/src/main/java/axoloti/object/AxoObjects.java
@@ -94,6 +94,7 @@ public class AxoObjects {
                 if (f.isFile()) {
                     AxoObjectAbstract o = new AxoObjectFromPatch(f);
                     o.createdFromRelativePath = true;
+                    o.sPath=f.getPath();
                     if (o != null) {
                         Logger.getLogger(AxoObjects.class.getName()).log(Level.INFO, "hit : " + fnameP);
                         set.add(o);
@@ -116,6 +117,8 @@ public class AxoObjects {
                 File f = new File(fname);
                 if (f.isFile()) {
                     AxoObjectAbstract o = new AxoObjectFromPatch(f);
+                    o.createdFromRelativePath = true;
+                    o.sPath = n + ".axp";
                     if (o != null) {
                         Logger.getLogger(AxoObjects.class.getName()).log(Level.INFO, "attempt to create object from patch file succeeded :" + fname);
                         set.add(o);


### PR DESCRIPTION
…en loading from a search path

this solves #41 , but I think we need to review using absolute paths, and move to using only relative paths... which are resolved using 
search path
patch directory
current working directory ( this is only used for unsaved patches, where we are assuming they will save to CWD)