### PR TITLE
Update 49-axoloti.rules

### DIFF
--- a/platform_linux/49-axoloti.rules
+++ b/platform_linux/49-axoloti.rules
@@ -1,4 +1,4 @@
 # 16C0:0442 - Axoloti Core
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16C0", ATTRS{idProduct}=="0442", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="0442", MODE:="0666"
 # 0483:df11 - Axoloti Core (STM32 microcontroller) in DFU mode
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666"


### PR DESCRIPTION
typo in 49-axoloti.rules tripped up device-matching
now allows connecting to axoloti-core as normal user