### PR TITLE
fix rfft&brainwave. ensure generated and axo are in sync

### DIFF
--- a/objects/brainwave/read.axo
+++ b/objects/brainwave/read.axo
@@ -1,6 +1,6 @@
 <objdefs>
-   <obj.normal id="read" uuid="d09a92cea8a12f1b046368d69b92b47831c11cbf" sha="b63bba67d51fdaba4822ef88cb13b748703e946d">
-      <upgradeSha>8847449eb00f524bb9181fc4f1bb7fcfadd160c6</upgradeSha>
+   <obj.normal id="read" uuid="d09a92cea8a12f1b046368d69b92b47831c11cbf" sha="c32f560b7385bac99cbb94cafc37204625604930">
+      <upgradeSha>a471bfa7649203d39f8c83f670278ad6743be2f5</upgradeSha>
       <sDescription>script with 2 inputs and 2 outputs, running in a separate thread, you must define &quot;void init(void){}&quot; and &quot;void loop(void)&quot;</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -44,7 +44,7 @@ msg_t ThreadX2(){
   chThdExit((msg_t)0);
 }
 static msg_t ThreadX(void *arg) {
-((attr_class *)arg)->ThreadX2();
+((attr_parent *)arg)->ThreadX2();
 }
 WORKING_AREA(waThreadX, 1024);
 Thread *Thd;

--- a/objects/delay/write sdram.axo
+++ b/objects/delay/write sdram.axo
@@ -1,7 +1,7 @@
 <objdefs>
    <obj.normal id="write sdram" uuid="5ae03f8d7b815edcfc40585d8bbac2ed48460fba" sha="ccc0fca1df0b5969e5e326c1c05d5394d1d2256a">
       <upgradeSha>3b156a92fef726fce69a05c2e670a365457a1728</upgradeSha>
-      <sDescription>delayline definition, read with delay/read</sDescription>
+      <sDescription>delayline definition, read it with &quot;delay/read&quot; objects referencing the instance name of this object</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
       <inlets>

--- a/objects/spectral/rfft 128.axo
+++ b/objects/spectral/rfft 128.axo
@@ -1,6 +1,6 @@
 <objdefs>
-   <obj.normal id="rfft 128" uuid="27b4fa628dda621136f74e407ee8761ba76f631c" sha="880bb070540dc79d589e772d8d6934845e1cf0f8">
-      <upgradeSha>2b19583e5fb37dcff1259d91d97ac49f46a8c912</upgradeSha>
+   <obj.normal id="rfft 128" uuid="27b4fa628dda621136f74e407ee8761ba76f631c" sha="1e5ec296644678b7bb811cbba8dfac44e890dcb9">
+      <upgradeSha>38b87d809e1f4ce40fa6651b081e68e82f80d2b2</upgradeSha>
       <sDescription>spectral analyzer display using 128 input points fft</sDescription>
       <author>Johannes Taelman</author>
       <license>BSD</license>
@@ -66,7 +66,7 @@ msg_t ThreadX2(){
       }
 }
 static msg_t ThreadX(void *arg) {
-((attr_class *)arg)->ThreadX2();
+((attr_parent *)arg)->ThreadX2();
 }
 WORKING_AREA(waThreadX, 4096);
 Thread *Thd;

--- a/objects/wave/longdelay.axo
+++ b/objects/wave/longdelay.axo
@@ -19,8 +19,8 @@
          <table name="fn"/>
       </attribs>
       <includes>
-         <include>chibios/ext/fatfs/src/ff.h</include>
          <include>./looper.h</include>
+         <include>chibios/ext/fatfs/src/ff.h</include>
       </includes>
       <code.declaration><![CDATA[   WORKING_AREA(waThreadSD, 1024);
    sdFilePingpongRW *stream;

--- a/src/main/java/generatedobjects/Distortion.java
+++ b/src/main/java/generatedobjects/Distortion.java
@@ -45,7 +45,7 @@ public class Distortion extends gentools {
         WriteAxoObject(catName, new AxoObject[]{Create_Slew(), Create_SlewTilde()});
         WriteAxoObject(catName, Create_Rectify());
         WriteAxoObject(catName, Create_Rectify_full());
-        WriteAxoObject(catName, Create_Rectify_lab());
+//UNRELEASED        WriteAxoObject(catName, Create_Rectify_lab());
 
     }
 

--- a/src/main/java/generatedobjects/Filter.java
+++ b/src/main/java/generatedobjects/Filter.java
@@ -73,7 +73,7 @@ public class Filter extends gentools {
         WriteAxoObject(catName, Create_hpfsvf_tilde());
         WriteAxoObject(catName, Create_bpfsvf_tilde());
 
-        WriteAxoObject(catName, Create_lpfsvf_drive());
+//UNRELEASED        WriteAxoObject(catName, Create_lpfsvf_drive());
 
         WriteAxoObject(catName, Create_bp_svf_m());
 

--- a/src/main/java/generatedobjects/LTC.java
+++ b/src/main/java/generatedobjects/LTC.java
@@ -37,8 +37,8 @@ public class LTC extends gentools {
         String catName = "ltc";
         WriteAxoObject(catName, Create_Generator());
         WriteAxoObject(catName, Create_Decoder());
-        WriteAxoObject(catName, Create_FSync());
-        WriteAxoObject(catName, Create_FSyncCoded());
+//UNRELEASED        WriteAxoObject(catName, Create_FSync());        
+//UNRELEASED        WriteAxoObject(catName, Create_FSyncCoded());
     }
 
     static AxoObject Create_Generator() {

--- a/src/main/java/generatedobjects/Spectral.java
+++ b/src/main/java/generatedobjects/Spectral.java
@@ -90,7 +90,7 @@ public class Spectral extends gentools {
                 + "      }\n"
                 + "}\n"
                 + "static msg_t ThreadX(void *arg) {\n"
-                + "((attr_class *)arg)->ThreadX2();\n"
+                + "((attr_parent *)arg)->ThreadX2();\n"
                 + "}\n";
         o.sLocalData += "WORKING_AREA(waThreadX, 4096);\n"
                 + "Thread *Thd;\n";
@@ -164,7 +164,7 @@ public class Spectral extends gentools {
                 + "      }\n"
                 + "}\n"
                 + "static msg_t ThreadX(void *arg) {\n"
-                + "((attr_class *)arg)->ThreadX2();\n"
+                + "((attr_parent *)arg)->ThreadX2();\n"
                 + "}\n";
         o.sLocalData += "WORKING_AREA(waThreadX, 4096);\n"
                 + "Thread *Thd;\n";
@@ -238,7 +238,7 @@ public class Spectral extends gentools {
                 + "      }\n"
                 + "}\n"
                 + "static msg_t ThreadX(void *arg) {\n"
-                + "((attr_class *)arg)->ThreadX2();\n"
+                + "((attr_parent *)arg)->ThreadX2();\n"
                 + "}\n";
         o.sLocalData += "WORKING_AREA(waThreadX, 16384);\n"
                 + "Thread *Thd;\n";

--- a/src/main/java/generatedobjects/Wave.java
+++ b/src/main/java/generatedobjects/Wave.java
@@ -46,12 +46,12 @@ public class Wave extends gentools {
         WriteAxoObject(catName, Create_playWave3Stereo());
         WriteAxoObject(catName, Create_playWave3Mono_fn());
         WriteAxoObject(catName, Create_playWave3Stereo_fn());
-        WriteAxoObject(catName, Create_playWave3Stereo_fn_32());
+//UNRELEASED        WriteAxoObject(catName, Create_playWave3Stereo_fn_32());
         WriteAxoObject(catName, Create_playFlashWave());
         WriteAxoObject(catName, Create_FlashWaveRead2());
         WriteAxoObject(catName, Create_Benchmark());
         //WriteAxoObject(dirname, Create_FlashWaveRead2());
-        WriteAxoObject(catName, Create_recWave2());
+//UNRELEASED         WriteAxoObject(catName, Create_recWave2());
         WriteAxoObject(catName, Create_Looper());
     }
 

--- a/src/main/java/generatedobjects/brainwave.java
+++ b/src/main/java/generatedobjects/brainwave.java
@@ -68,7 +68,7 @@ public class brainwave extends gentools {
                 + "  chThdExit((msg_t)0);\n"
                 + "}\n"
                 + "static msg_t ThreadX(void *arg) {\n"
-                + "((attr_class *)arg)->ThreadX2();\n"
+                + "((attr_parent *)arg)->ThreadX2();\n"
                 + "}\n";
         o.sLocalData += "WORKING_AREA(waThreadX, 1024);\n"
                 + "Thread *Thd;\n";


### PR DESCRIPTION
Ive commented out some objects in generated, as the axo objects have not been checked in.
(so Ive assumed they are not ready for release)
Ive marked with //UNRELEASED, these are:
	objects/dist/rectifierlab.axo
	objects/filter/lp svf drive.axo
	objects/ltc/fsync coded.axo
	objects/ltc/fsync.axo
	objects/wave/play3 fn stereo 32.axo
	objects/wave/record.axo

if you think that some of these should be released, then un-comment and check axo in.
(I think we should ensure axo's and generated are always in sync, just so we know its always safe to regenerate objects)