### PR TITLE
installation improvements , issue #94

### DIFF
--- a/Axoloti.command
+++ b/Axoloti.command
@@ -2,7 +2,8 @@
 rootdir="$(cd $(dirname $0); pwd -P)"
 export axoloti_release=${axoloti_release:="$rootdir"}
 export axoloti_runtime=${axoloti_runtime:="$rootdir"}
-export axoloti_build=${axoloti_build:="$rootdir/patch"}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
 
 cd $rootdir
 

--- a/Axoloti.sh
+++ b/Axoloti.sh
@@ -8,14 +8,16 @@ case "$unamestr" in
 		rootdir="$(dirname $(readlink -f $0))"
 		export axoloti_release=${axoloti_release:="$rootdir"}
 		export axoloti_runtime=${axoloti_runtime:="$rootdir"}
-		export axoloti_build=${axoloti_build:="$rootdir/patch"}
+		export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+		export axoloti_home=${axoloti_home:="$rootdir"}
 	;;
 	Darwin)
 		platform='mac'
 		rootdir="$(cd $(dirname $0); pwd -P)"
 		export axoloti_release=${axoloti_release:="$rootdir"}
 		export axoloti_runtime=${axoloti_runtime:="$rootdir"}
-		export axoloti_build=${axoloti_build:="$rootdir/patch"}
+		export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+		export axoloti_home=${axoloti_home:="$rootdir"}
 	;;
         *)
                 echo "unknown OS : $unamestr, aborting..."

--- a/build.xml
+++ b/build.xml
@@ -118,6 +118,41 @@
 
   <target name="-post-jar">
 	<antcall target="bundle"/>
+	<antcall target="runtime"/>
+  </target>
+
+  <target name="runtime" if="build.runtime">
+		<mkdir dir="build/runtime"/>
+		<mkdir dir="build/runtime/macosx" />
+		<mkdir dir="build/runtime/macosx/axoloti_runtime" />
+		<exec dir="." executable="cp">
+			<arg line="-R CMSIS build/runtime/tmp/axoloti_runtime"/>
+		</exec>
+		<exec dir="." executable="cp">
+			<arg line="-R chibios build/runtime/macosx/axoloti_runtime"/>
+		</exec>
+		<exec dir="." executable="cp">
+			<arg line="-R patch build/runtime/macosx/axoloti_runtime"/>
+		</exec>
+
+		<!--Mac -->
+		<exec dir="." executable="cp" os="Mac OS X">
+			<arg line="-R platform_osx build/runtime/tmp/axoloti_runtime"/>
+		</exec>
+		<exec dir="." executable="hdiutil" os="Mac OS X">
+			<arg line="create -megabytes 400 build/runtime/macosx/axoloti_runtime.dmg -volname 'Axoloti Runtime'  -srcfolder build/runtime/tmp" />
+		</exec>
+		<!--Linux -->
+		<exec dir="." executable="cp" os="Linux">
+			<arg line="-R platform_linux build/runtime/tmp/axoloti_runtime"/>
+		</exec>
+		<mkdir dir="build/runtime/linux"/>
+		<exec dir="build/runtime/tmp" executable="tar" os="Linux">
+			<arg value="-cvf"/>
+			<arg value="../linux/axoloti_runtime.zip"/>
+			<arg value="."/>
+		</exec>
+		<!--Windows -->
   </target>
 
   <target name="bundle" if="build.bundle">
@@ -147,11 +182,6 @@
 			 <include name="objects/**/*"/>
 			 <include name="firmware/**/*"/>
 			 <include name="*.txt"/>
-<!--
-			 <include name="chibios/**/*"/>
-			 <include name="CMSIS/**/*"/>
-			 <include name="platform*/**/*"/>
--->
 		 </fx:fileset>
 	</fx:resources>
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -60,8 +60,11 @@ PROJECT = axoloti
 # Imported source files and paths
 axoloti_runtime ?= ..
 axoloti_release ?= ..
+axoloti_home ?= ..
+axoloti_firmware ?= ../firmware
+
 CHIBIOS = ${axoloti_runtime}/chibios
-FIRMWARE = ${axoloti_release}/firmware
+FIRMWARE = ${axoloti_firmware}
 
 include board.mk
 include $(CHIBIOS)/os/hal/platforms/STM32F4xx/platform.mk

--- a/patch/Makefile
+++ b/patch/Makefile
@@ -15,10 +15,11 @@ DMP=arm-none-eabi-objdump
 
 axoloti_runtime ?= ..
 axoloti_release ?= ..
-axoloti_build ?= .
+axoloti_home ?= ..
+axoloti_firmware ?= ../firmware
 CHIBIOS = ${axoloti_runtime}/chibios
 CMSIS = ${axoloti_runtime}/CMSIS
-BDIR = ${axoloti_build}
+BDIR = ${axoloti_home}/build
 
 
 include $(CHIBIOS)/boards/ST_STM32F4_DISCOVERY/board.mk
@@ -31,7 +32,7 @@ include $(CHIBIOS)/os/various/fatfs_bindings/fatfs.mk
 INCDIR = $(CMSIS)/Include \
 		 $(PORTINC) $(KERNINC) $(TESTINC) \
          $(HALINC) $(PLATFORMINC) $(BOARDINC) $(FATFSINC) \
-         ${axoloti_release}/firmware
+         ${axoloti_firmware}
          
 # Paths
 IINCDIR   = $(patsubst %,-I%,$(INCDIR) $(DINCDIR) $(UINCDIR))

--- a/platform_linux/compile_firmware.sh
+++ b/platform_linux/compile_firmware.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -e
 platformdir="$(dirname $(readlink -f $0))"
-cd ${platformdir}/../firmware
+
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+
+cd ${axoloti_firmware}
 if [ ! -d "build" ]; 
 then
     mkdir "build"
@@ -16,7 +22,7 @@ then
 fi
 echo "Compiling firmware..."
 make
-cd ${platformdir}/../firmware/flasher
+cd ${axoloti_firmware}/flasher
 if [ ! -d "flasher_build" ]; 
 then
     mkdir "flasher_build"

--- a/platform_linux/compile_patch.sh
+++ b/platform_linux/compile_patch.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 platformdir="$(dirname $(readlink -f $0))"
-cd $platformdir/../patch
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+cd ${axoloti_release}/patch
 make

--- a/platform_linux/upload_fw_dfu.sh
+++ b/platform_linux/upload_fw_dfu.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 platformdir="$(dirname $(readlink -f $0))"
 
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+
 if [ -f "${platformdir}/bin/dfu-util" ];
 then
     cd "${platformdir}"/../
-    "${platformdir}"/bin/dfu-util --device 0483:df11 -i 0 -a 0 -D firmware/build/axoloti.bin --dfuse-address=0x08000000:leave
+    "${platformdir}"/bin/dfu-util --device 0483:df11 -i 0 -a 0 -D ${axoloti_firmware}/build/axoloti.bin --dfuse-address=0x08000000:leave
 else
     echo "dfu-util not found, run ./install.sh in axoloti/platform_linux"
 fi

--- a/platform_osx/compile_firmware.sh
+++ b/platform_osx/compile_firmware.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 platformdir="$(cd $(dirname $0); pwd -P)"
+
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+
 export PATH=$PATH:${platformdir}/gcc-arm-none-eabi-4_8-2014q3/bin/:${platformdir}/bin
 #echo $PATH
-cd ${platformdir}/../firmware
+cd ${axoloti_firmware}
 echo "Compiling firmware..."
 make
 cd flasher

--- a/platform_osx/compile_patch.sh
+++ b/platform_osx/compile_patch.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 platformdir="$(cd $(dirname $0); pwd -P)"
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+
 export PATH=$PATH:${platformdir}/gcc-arm-none-eabi-4_8-2014q3/bin/:${platformdir}/bin
-cd ${platformdir}/../patch
+cd ${axoloti_runtime}/patch
 make

--- a/platform_osx/upload_fw_dfu.sh
+++ b/platform_osx/upload_fw_dfu.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 platformdir="$(cd $(dirname $0); pwd -P)"
+
+export axoloti_release=${axoloti_release:="$platformdir/.."}
+export axoloti_runtime=${axoloti_runtime:="$platformdir/.."}
+export axoloti_firmware=${axoloti_firmware:="$axoloti_release/firmware"}
+export axoloti_home=${axoloti_home:="$rootdir"}
+
 cd ${platformdir}/bin
-./dfu-util --device 0483:df11 -i 0 -a 0 -D ../../firmware/build/axoloti.bin --dfuse-address=0x08000000:leave
+./dfu-util --device 0483:df11 -i 0 -a 0 -D ${axoloti_firmware}/build/axoloti.bin --dfuse-address=0x08000000:leave

--- a/src/main/java/axoloti/Axoloti.java
+++ b/src/main/java/axoloti/Axoloti.java
@@ -29,8 +29,9 @@ import javax.swing.UIManager;
 public class Axoloti {
 
     public final static String RUNTIME_DIR = "axoloti_runtime";
-    public final static String BUILD_DIR = "axoloti_build";
+    public final static String HOME_DIR = "axoloti_home";
     public final static String RELEASE_DIR = "axoloti_release";
+    public final static String FIRMWARE_DIR = "axoloti_firmware";
 
     static void BuildEnv(String var, String def) {
         String ev = System.getProperty(var);
@@ -73,16 +74,32 @@ public class Axoloti {
             if (!TestDir(RUNTIME_DIR)) {
                 System.exit(-1);
             }
-            BuildEnv(BUILD_DIR, curDir + File.separator + "patch");
-            if (!TestDir(BUILD_DIR)) {
+
+            BuildEnv(FIRMWARE_DIR, System.getProperty(RELEASE_DIR) + File.separator + "firmware");
+            if (!TestDir(FIRMWARE_DIR)) {
                 System.exit(-1);
             }
 
-            System.out.println("Axoloti Dirs:\n"
-                    + "CurrentDir = " + curDir + "\n"
-                    + "ReleaseDir = " + System.getProperty(RELEASE_DIR) + "\n"
-                    + "RuntimeDir = " + System.getProperty(RUNTIME_DIR) + "\n"
-                    + "BuildDir = " + System.getProperty(BUILD_DIR)
+            BuildEnv(HOME_DIR, curDir);
+            File homedir = new File(System.getProperty(HOME_DIR));
+            if (!homedir.exists()) {
+                homedir.mkdir();
+            }
+            File buildir = new File(System.getProperty(HOME_DIR) + File.separator + "build");
+            if (!buildir.exists()) {
+                buildir.mkdir();
+            }
+
+            if (!TestDir(HOME_DIR)) {
+                System.exit(-1);
+            }
+
+            System.out.println("Axoloti Driectories:\n"
+                    + "Current = " + curDir + "\n"
+                    + "Release = " + System.getProperty(RELEASE_DIR) + "\n"
+                    + "Runtime = " + System.getProperty(RUNTIME_DIR) + "\n"
+                    + "Firware = " + System.getProperty(FIRMWARE_DIR) + "\n"
+                    + "AxolotiHome = " + System.getProperty(HOME_DIR)
             );
 
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -1761,7 +1761,7 @@ public class Patch {
         String c = GenerateCode3();
 
         try {
-            String buildDir=System.getProperty(Axoloti.BUILD_DIR);
+            String buildDir=System.getProperty(Axoloti.HOME_DIR)+"/build";
             FileOutputStream f = new FileOutputStream(buildDir+"/xpatch.cpp");
             f.write(c.getBytes());
             f.close();

--- a/src/main/java/qcmds/QCmdCompileFirmware.java
+++ b/src/main/java/qcmds/QCmdCompileFirmware.java
@@ -19,6 +19,7 @@ package qcmds;
 
 import axoloti.MainFrame;
 import axoloti.utils.OSDetect;
+import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -39,11 +40,9 @@ public class QCmdCompileFirmware extends QCmdShellTask {
         return "Done compiling firmware";
     }
     
-    //FIXME: we should be using the build dir here, not the release area
     @Override
-    public String BuildDir() {
-//        return System.getProperty(axoloti.Axoloti.BUILD_DIR);
-        return System.getProperty(axoloti.Axoloti.RUNTIME_DIR);
+    public File GetWorkingDir() {
+        return new File(System.getProperty(axoloti.Axoloti.FIRMWARE_DIR));
     }
     
     @Override

--- a/src/main/java/qcmds/QCmdFlashDFU.java
+++ b/src/main/java/qcmds/QCmdFlashDFU.java
@@ -18,6 +18,7 @@
 package qcmds;
 
 import axoloti.utils.OSDetect;
+import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,12 +42,11 @@ public class QCmdFlashDFU extends QCmdShellTask {
         }
     }
     
-    //FIXME: we should be using the build dir here, not the release area
     @Override
-    public String BuildDir() {
-//        return System.getProperty(axoloti.Axoloti.BUILD_DIR);
-        return System.getProperty(axoloti.Axoloti.RUNTIME_DIR);
+    public File GetWorkingDir() {
+        return new File(System.getProperty(axoloti.Axoloti.FIRMWARE_DIR));
     }
+    
     
     @Override
     String GetExec() {

--- a/src/main/java/qcmds/QCmdShellTask.java
+++ b/src/main/java/qcmds/QCmdShellTask.java
@@ -70,8 +70,8 @@ public abstract class QCmdShellTask implements QCmd {
         return System.getProperty(axoloti.Axoloti.RUNTIME_DIR);
     }
 
-    public String BuildDir() {
-        return System.getProperty(axoloti.Axoloti.BUILD_DIR);
+    public String HomeDir() {
+        return System.getProperty(axoloti.Axoloti.HOME_DIR);
     }
             
     public String ReleaseDir() {
@@ -85,7 +85,7 @@ public abstract class QCmdShellTask implements QCmd {
             list.add((v + "=" + env.get(v)));
         }
         list.add((axoloti.Axoloti.RUNTIME_DIR + "=" + RuntimeDir()));
-        list.add((axoloti.Axoloti.BUILD_DIR + "=" + BuildDir()));
+        list.add((axoloti.Axoloti.HOME_DIR + "=" + HomeDir()));
         list.add((axoloti.Axoloti.RELEASE_DIR + "=" + ReleaseDir()));
 
         String vars[] = new String[list.size()];
@@ -94,7 +94,7 @@ public abstract class QCmdShellTask implements QCmd {
     }
 
     public File GetWorkingDir() {
-        return new File(BuildDir());
+        return new File(HomeDir()+"/build");
     }
 
     public QCmd Do(QCmdProcessor shellProcessor) {

--- a/src/main/java/qcmds/QCmdUploadFWSDRam.java
+++ b/src/main/java/qcmds/QCmdUploadFWSDRam.java
@@ -58,10 +58,7 @@ public class QCmdUploadFWSDRam implements QCmdSerialTask {
         connection.ClearSync();
         try {
             if (f == null) {
-                //String buildDir = System.getProperty(Axoloti.BUILD_DIR);
-                
-                //FIXME: this should be in a build directory outside the package
-                String buildDir = System.getProperty(Axoloti.RUNTIME_DIR) + "/firmware/build";
+                String buildDir = System.getProperty(Axoloti.FIRMWARE_DIR) + "/build";
                 f = new File(buildDir+"/axoloti.bin");
             }
             Logger.getLogger(QCmdUploadFWSDRam.class.getName()).log(Level.INFO, "firmware file path: " + f.getAbsolutePath());

--- a/src/main/java/qcmds/QCmdUploadPatch.java
+++ b/src/main/java/qcmds/QCmdUploadPatch.java
@@ -57,7 +57,7 @@ public class QCmdUploadPatch implements QCmdSerialTask {
         connection.ClearSync();
         try {
             if (f == null) {
-                String buildDir = System.getProperty(Axoloti.BUILD_DIR);
+                String buildDir=System.getProperty(Axoloti.HOME_DIR)+"/build";
                 f = new File(buildDir + "/xpatch.bin");
             }
             Logger.getLogger(QCmdUploadPatch.class.getName()).log(Level.INFO, "bin path: " + f.getAbsolutePath());

--- a/src/main/java/qcmds/QCmdWriteFile.java
+++ b/src/main/java/qcmds/QCmdWriteFile.java
@@ -58,7 +58,7 @@ public class QCmdWriteFile implements QCmdSerialTask {
         Connection.ClearSync();
         try {
             Thread.sleep(100);
-            String buildDir = System.getProperty(Axoloti.BUILD_DIR);
+            String buildDir=System.getProperty(Axoloti.HOME_DIR)+"/build";;
             File f = new File(buildDir + "/xpatch.bin");
             Logger.getLogger(QCmdWriteFile.class.getName()).log(Level.INFO, "bin path: " + f.getAbsolutePath());
             byte[] buffer = new byte[(int) f.length()];


### PR DESCRIPTION
- new build.runtime target for mac and linux to build a runtime image, linux gets a tar file, mac gets a DMG
- new firmware environment var used to pickup firmware, defaults to release area, but can be overridden by user to build from somewhere else (axoloti home/firmware is good)
- axoloti_home replaces axoloti_build

to do
- store preferences in axoloti_home/preferences.xml
- create 'default firmware upload menu'
- test with an application bundle.
- compile/upload scripts for windows (in platform_win), copy pattern used by linux/osx
- build.runtime for windows... again copy linux/osx model
NOTE: build.xml deliberately uses native commands it HAS to to ensure file permissions are left intact, all ANT tasks will remove execute permissions. (and they are a pain to add back!)